### PR TITLE
Change run directory for ccpp_prebuild.py from TOP_DIR/ccpp-framework…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,24 @@ for an atmospheric model to interact with physics through the CCPP.
 1. Run the CCPP prebuild script to match required physics variables with those
 available from the dycore (SCM) and to generate physics caps and makefile
 segments.
-  * `cd ccpp-framework/scripts`
-  * `./ccpp_prebuild.py`
-  Note: use `./ccpp_prebuild.py --debug` to see the full output of the script.
+  * `./ccpp-framework/scripts/ccpp_prebuild.py`
+  Note: add `--debug` to see the full output of the script.
 2. Change directory to the top-level SCM directory.
-  * `cd ../../scm`
+  * `cd scm`
 3. [Optional] Run the machine setup script if necessary. This script loads
 compiler modules (Fortran 2003-compliant Intel), netCDF module, etc. and sets
 compiler environment variables.
   * `source etc/Theia_setup.csh` (for csh) or `. etc/Theia_setup.sh` (for bash)
   * `source etc/Cheyenne_setup.csh` (for csh) or `. etc/Cheyenne_setup.sh` (for bash)
   * `source etc/MACOSX_setup.csh` (for csh) or `. etc/MACOSX_setup.sh` (for bash) if following the instructions in doc/README_MACOSX.txt
-3. Make a build directory and change into it.
+4. Make a build directory and change into it.
   * `mkdir bin && cd bin`
-4. Invoke cmake on the source code to build.
+5. Invoke cmake on the source code to build.
   * `cmake ../src` (without threading/OpenMP)
   * `cmake -DOPENMP=1 ../src` (with threading/OpenMP)
 
   For extensive debugging output, add `-DCMAKE_BUILD_TYPE=Debug` to the `cmake` command.
-5. Compile. Add `VERBOSE=1` to obtain more information on the build process.
+6. Compile. Add `VERBOSE=1` to obtain more information on the build process.
   * `make`
 
 ## Running the SCM with CCPP


### PR DESCRIPTION
This PR updates the documentation for how to run ccpp_prebuild.py for SCM (from TOP_DIR instead of from TOP_DIR/ccpp-framework/scripts) and corrects a few typos.