### PR TITLE
Updating case configuration files to use GFDL MP by default

### DIFF
--- a/scm/etc/case_config/LASSO_2016051812.nml
+++ b/scm/etc/case_config/LASSO_2016051812.nml
@@ -25,7 +25,7 @@ hour = 12,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/LASSO_2016051812_MSDA.nml
+++ b/scm/etc/case_config/LASSO_2016051812_MSDA.nml
@@ -25,7 +25,7 @@ hour = 12,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/LASSO_2016051812_VARA.nml
+++ b/scm/etc/case_config/LASSO_2016051812_VARA.nml
@@ -25,7 +25,7 @@ hour = 12,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_A.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_A.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_A_2017_GFS.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_A_2017_GFS.nml
@@ -7,7 +7,7 @@ time_scheme = 1,
 runtime = 345600,
 output_frequency = 600.0,
 n_levels = 64,
-output_dir = 'output_arm_sgp_summer_1997_A_gfdlmp',
+output_dir = 'output_arm_sgp_summer_1997_A_2017_GFS',
 output_file = 'output',
 case_data_dir = '../data/processed_case_input',
 vert_coord_data_dir = '../data/vert_coord_data',
@@ -25,8 +25,8 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
-physics_nml = '../etc/case_config/input_gfdl.nml',
+physics_nml = '../etc/case_config/input_2017_GFS.nml',
 column_area = 2.0E9,
 $end

--- a/scm/etc/case_config/arm_sgp_summer_1997_B.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_B.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_C.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_C.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_R.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_R.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_S.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_S.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_T.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_T.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_U.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_U.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/arm_sgp_summer_1997_X.nml
+++ b/scm/etc/case_config/arm_sgp_summer_1997_X.nml
@@ -25,7 +25,7 @@ hour = 23,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/astex.nml
+++ b/scm/etc/case_config/astex.nml
@@ -24,7 +24,7 @@ hour = 0,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated',
+physics_suite = 'suite_SCM_GFS_2018_updated',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 3.7E5,

--- a/scm/etc/case_config/bomex.nml
+++ b/scm/etc/case_config/bomex.nml
@@ -25,7 +25,7 @@ hour = 13,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated_prescribed_surface',
+physics_suite = 'suite_SCM_GFS_2018_updated_prescribed_surface',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/default.nml
+++ b/scm/etc/case_config/default.nml
@@ -24,7 +24,7 @@ hour = 3,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated',
+physics_suite = 'suite_SCM_GFS_2018_updated',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/input.nml
+++ b/scm/etc/case_config/input.nml
@@ -11,7 +11,8 @@
        blocksize = 32
        chksum_debug = .false.
        dycore_only = .false.
-       ccpp_suite = "suite_GFS_IPD.xml"
+       fdiag = @[FDIAG]
+       ccpp_suite = 'ccpp_suite.xml'
 /
 
 &diag_manager_nml
@@ -26,7 +27,7 @@
 
 &fms_nml
        clock_grain = 'ROUTINE',
-       domains_stack_size = 115200,
+       domains_stack_size = 3000000,
        print_memory_usage = .false.
 /
 
@@ -40,14 +41,15 @@
        npx      = 97
        npy      = 97
        ntiles   = 6,
-       npz    = 63
+       npz    = @[NPZ]
        grid_type = -1
        make_nh = @[MAKE_NH]
        fv_debug = .F.
        range_warn = .F.
        reset_eta = .F.
-       n_sponge = 24
+       n_sponge = 30
        nudge_qv = .T.
+       rf_fast = .F.
        tau = 5.
        rf_cutoff = 7.5e2
        d2_bg_k1 = 0.15
@@ -62,13 +64,13 @@
        beta = 0.
        a_imp = 1.
        p_fac = 0.1
-       k_split  = 2
-       n_split  = 6
-       nwat = 2
+       k_split  = 1
+       n_split  = 8
+       nwat = 6
        na_init = @[NA_INIT]
        d_ext = 0.0
-       dnats = 0
-       fv_sg_adj = 450
+       dnats = 1
+       fv_sg_adj = 600
        d2_bg = 0.
        nord =  2
        dddmp = 0.1
@@ -78,6 +80,7 @@
        ke_bg = 0.
        do_vort_damp = .true.
        external_ic = @[EXTERNAL_IC]
+       external_eta = .T.
        gfs_phil = .false.
        nggps_ic = @[NGGPS_IC]
        mountain = @[MOUNTAIN]
@@ -86,15 +89,18 @@
        hord_mt =  6
        hord_vt =  6
        hord_tm =  6
-       hord_dp =  6
+       hord_dp =  -6
        hord_tr = 8
        adjust_dry_mass = .F.
        consv_te = 1.
+       do_sat_adj = .T.
        consv_am = .F.
        fill = .T.
        dwind_2d = .F.
        print_freq = 6
        warm_start = @[WARM_START]
+       read_increment = @[READ_INCREMENT]
+       res_latlon_dynamics = "fv3_increment.nc"
        no_dycore = .false.
        z_tracer = .T.
 /
@@ -103,8 +109,8 @@
 #       months = 0
 #       days  = 1
 #       hours = 0
-#       dt_atmos = 225
-#       dt_ocean = 225
+#       dt_atmos = 1200
+#       dt_ocean = 1200
 #       current_date =  2016,10,03,00,0,0
 #       calendar = 'julian'
 #       memuse_verbose = .false.
@@ -115,8 +121,7 @@
 
 &external_ic_nml
        filtered_terrain = .true.
-       ncep_plevels = .true.
-       levp = 64
+       levp = @[NPZP]
        gfs_dwinds = .true.
        checker_tr = .F.
        nt_checker = 0
@@ -129,8 +134,8 @@
        nst_anl        = .true.
        use_ufo        = .true.
        pre_rad        = .false.
-       ncld           = 1
-       imp_physics    = 99
+       ncld           = 5
+       imp_physics    = 11
        pdfcld         = .false.
        fhswr          = 3600.
        fhlwr          = 3600.
@@ -149,7 +154,8 @@
        redrag         = .true.
        dspheat        = .true.
        hybedmf        = .true.
-       random_clds    = .true.
+       satmedmf       = .false.
+       random_clds    = .false.
        trans_trac     = .false.
        cnvcld         = .true.
        imfshalcnv     = 2
@@ -163,12 +169,61 @@
        xkzminv        = 0.3
        xkzm_m         = 1.0
        xkzm_h         = 1.0
+       do_sppt        = .false.
+       do_shum        = .false.
+       do_skeb        = .false.
+       do_sfcperts    = .false.
        jcap = 574
-
 /
 
-&nggps_diag_nml
-       fdiag = @[FDIAG]
+&gfdl_cloud_microphysics_nml
+       sedi_transport = .true.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 300.
+       tau_l2v = 225.
+       tau_v2l = 150.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 150.
 /
 
 &interpolator_nml
@@ -215,4 +270,8 @@
        FABSL    = 99999,
        FSNOS    = 99999,
        FSICS    = 99999,
+/
+&nam_stochy
+/
+&nam_sfcperts
 /

--- a/scm/etc/case_config/input_2017_GFS.nml
+++ b/scm/etc/case_config/input_2017_GFS.nml
@@ -11,8 +11,7 @@
        blocksize = 32
        chksum_debug = .false.
        dycore_only = .false.
-       fdiag = @[FDIAG]
-       ccpp_suite = 'ccpp_suite.xml'
+       ccpp_suite = "suite_GFS_IPD.xml"
 /
 
 &diag_manager_nml
@@ -27,7 +26,7 @@
 
 &fms_nml
        clock_grain = 'ROUTINE',
-       domains_stack_size = 3000000,
+       domains_stack_size = 115200,
        print_memory_usage = .false.
 /
 
@@ -41,15 +40,14 @@
        npx      = 97
        npy      = 97
        ntiles   = 6,
-       npz    = @[NPZ]
+       npz    = 63
        grid_type = -1
        make_nh = @[MAKE_NH]
        fv_debug = .F.
        range_warn = .F.
        reset_eta = .F.
-       n_sponge = 30
+       n_sponge = 24
        nudge_qv = .T.
-       rf_fast = .F.
        tau = 5.
        rf_cutoff = 7.5e2
        d2_bg_k1 = 0.15
@@ -64,13 +62,13 @@
        beta = 0.
        a_imp = 1.
        p_fac = 0.1
-       k_split  = 1
-       n_split  = 8
-       nwat = 6
+       k_split  = 2
+       n_split  = 6
+       nwat = 2
        na_init = @[NA_INIT]
        d_ext = 0.0
-       dnats = 1
-       fv_sg_adj = 600
+       dnats = 0
+       fv_sg_adj = 450
        d2_bg = 0.
        nord =  2
        dddmp = 0.1
@@ -80,7 +78,6 @@
        ke_bg = 0.
        do_vort_damp = .true.
        external_ic = @[EXTERNAL_IC]
-       external_eta = .T.
        gfs_phil = .false.
        nggps_ic = @[NGGPS_IC]
        mountain = @[MOUNTAIN]
@@ -89,18 +86,15 @@
        hord_mt =  6
        hord_vt =  6
        hord_tm =  6
-       hord_dp =  -6
+       hord_dp =  6
        hord_tr = 8
        adjust_dry_mass = .F.
        consv_te = 1.
-       do_sat_adj = .T.
        consv_am = .F.
        fill = .T.
        dwind_2d = .F.
        print_freq = 6
        warm_start = @[WARM_START]
-       read_increment = @[READ_INCREMENT]
-       res_latlon_dynamics = "fv3_increment.nc"
        no_dycore = .false.
        z_tracer = .T.
 /
@@ -109,8 +103,8 @@
 #       months = 0
 #       days  = 1
 #       hours = 0
-#       dt_atmos = 1200
-#       dt_ocean = 1200
+#       dt_atmos = 225
+#       dt_ocean = 225
 #       current_date =  2016,10,03,00,0,0
 #       calendar = 'julian'
 #       memuse_verbose = .false.
@@ -121,7 +115,8 @@
 
 &external_ic_nml
        filtered_terrain = .true.
-       levp = @[NPZP]
+       ncep_plevels = .true.
+       levp = 64
        gfs_dwinds = .true.
        checker_tr = .F.
        nt_checker = 0
@@ -134,8 +129,8 @@
        nst_anl        = .true.
        use_ufo        = .true.
        pre_rad        = .false.
-       ncld           = 5
-       imp_physics    = 11
+       ncld           = 1
+       imp_physics    = 99
        pdfcld         = .false.
        fhswr          = 3600.
        fhlwr          = 3600.
@@ -154,8 +149,7 @@
        redrag         = .true.
        dspheat        = .true.
        hybedmf        = .true.
-       satmedmf       = .false.
-       random_clds    = .false.
+       random_clds    = .true.
        trans_trac     = .false.
        cnvcld         = .true.
        imfshalcnv     = 2
@@ -169,61 +163,12 @@
        xkzminv        = 0.3
        xkzm_m         = 1.0
        xkzm_h         = 1.0
-       do_sppt        = .false.
-       do_shum        = .false.
-       do_skeb        = .false.
-       do_sfcperts    = .false.
        jcap = 574
+
 /
 
-&gfdl_cloud_microphysics_nml
-       sedi_transport = .true.
-       do_sedi_heat = .false.
-       rad_snow = .true.
-       rad_graupel = .true.
-       rad_rain = .true.
-       const_vi = .F.
-       const_vs = .F.
-       const_vg = .F.
-       const_vr = .F.
-       vi_max = 1.
-       vs_max = 2.
-       vg_max = 12.
-       vr_max = 12.
-       qi_lim = 1.
-       prog_ccn = .false.
-       do_qa = .true.
-       fast_sat_adj = .true.
-       tau_l2v = 300.
-       tau_l2v = 225.
-       tau_v2l = 150.
-       tau_g2v = 900.
-       rthresh = 10.e-6  ! This is a key parameter for cloud water
-       dw_land  = 0.16
-       dw_ocean = 0.10
-       ql_gen = 1.0e-3
-       ql_mlt = 1.0e-3
-       qi0_crt = 8.0E-5
-       qs0_crt = 1.0e-3
-       tau_i2s = 1000.
-       c_psaci = 0.05
-       c_pgacs = 0.01
-       rh_inc = 0.30
-       rh_inr = 0.30
-       rh_ins = 0.30
-       ccn_l = 300.
-       ccn_o = 100.
-       c_paut = 0.5
-       c_cracw = 0.8
-       use_ppm = .false.
-       use_ccn = .true.
-       mono_prof = .true.
-       z_slope_liq  = .true.
-       z_slope_ice  = .true.
-       de_ice = .false.
-       fix_negative = .true.
-       icloud_f = 1
-       mp_time = 150.
+&nggps_diag_nml
+       fdiag = @[FDIAG]
 /
 
 &interpolator_nml
@@ -270,8 +215,4 @@
        FABSL    = 99999,
        FSNOS    = 99999,
        FSICS    = 99999,
-/
-&nam_stochy
-/
-&nam_sfcperts
 /

--- a/scm/etc/case_config/twpice.nml
+++ b/scm/etc/case_config/twpice.nml
@@ -24,7 +24,7 @@ hour = 3,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2017_updated',
+physics_suite = 'suite_SCM_GFS_2018_updated',
 physics_suite_dir = '../../ccpp-framework/suites/',
 physics_nml = '../etc/case_config/input.nml',
 column_area = 2.0E9,

--- a/scm/etc/case_config/twpice_2017_GFS.nml
+++ b/scm/etc/case_config/twpice_2017_GFS.nml
@@ -7,7 +7,7 @@ time_scheme = 1,
 runtime = 2138400,
 output_frequency = 600.0,
 n_levels = 64,
-output_dir = 'output_twpice_gfdlmp',
+output_dir = 'output_twpice_2017_GFS',
 output_file = 'output',
 case_data_dir = '../data/processed_case_input',
 vert_coord_data_dir = '../data/vert_coord_data',
@@ -24,8 +24,8 @@ hour = 3,
 $end
 
 $physics_config
-physics_suite = 'suite_SCM_GFS_2018_updated',
+physics_suite = 'suite_SCM_GFS_2017_updated',
 physics_suite_dir = '../../ccpp-framework/suites/',
-physics_nml = '../etc/case_config/input_gfdl.nml',
+physics_nml = '../etc/case_config/input_2017_GFS.nml',
 column_area = 2.0E9,
 $end


### PR DESCRIPTION
update all case config files to use suite with GFDL MP; keep 2 cases using the old suite with Zhao-Carr as an example that use the 2017_GFS suffix