### PR TITLE
GFDL MP namelist bugfix

### DIFF
--- a/scm/etc/case_config/input_namelists/input_fv3_gfdlmp.nml
+++ b/scm/etc/case_config/input_namelists/input_fv3_gfdlmp.nml
@@ -62,8 +62,8 @@
        vr_max = 12.
        qi_lim = 1.
        prog_ccn = .false.
-       do_qa = .true.
-       fast_sat_adj = .true.
+       do_qa = .false.
+       fast_sat_adj = .false.
        tau_l2v = 300.
        tau_l2v = 225.
        tau_v2l = 150.

--- a/scm/etc/case_config/input_namelists/input_fv3_suite2.nml
+++ b/scm/etc/case_config/input_namelists/input_fv3_suite2.nml
@@ -62,8 +62,8 @@
        vr_max = 12.
        qi_lim = 1.
        prog_ccn = .false.
-       do_qa = .true.
-       fast_sat_adj = .true.
+       do_qa = .false.
+       fast_sat_adj = .false.
        tau_l2v = 300.
        tau_l2v = 225.
        tau_v2l = 150.


### PR DESCRIPTION
switched fast_sat_adj and do_qa in GFDL microphysics-containing namelists to F so that cloud fraction (and other things?) are calculated in the slow part of the scheme rather than that fast part that is not configured to work with the SCM (fixes bug discovered by @dustinswales)