### PR TITLE
dtc/develop: run CCPP prebuild step from cmake

### DIFF
--- a/scm/src/CMakeLists.txt
+++ b/scm/src/CMakeLists.txt
@@ -1,6 +1,61 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 PROJECT(scm)
 set(PROJECT "CCPP-SCM")
+
+####################################################################
+# Begin CCPP prebuild step                                         #
+####################################################################
+if(STATIC)
+  # Start with empty list of suites
+  message (STATUS "Generating list of suites to compile for static CCPP")
+  set(SUITES "")
+  # Get list of all suite definition files (with full path)
+  file(GLOB SUITE_DEFINITION_FILES
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../ccpp/suites/suite_*.xml"
+  )
+  # Extract file name and suite name and append to SUITES
+  foreach(suite_definition_filepath IN LISTS SUITE_DEFINITION_FILES)
+    get_filename_component(suite_definition_filename ${suite_definition_filepath} NAME)
+    string(REGEX REPLACE "^suite_(.+)\\.xml$" "\\1" suite_name ${suite_definition_filename})
+    string(APPEND SUITES "${suite_name},")
+    message (STATUS "  adding suite ${suite_name}")
+  endforeach(suite_definition_filepath IN LISTS SUITE_DEFINITION_FILES)
+  # Abort if no suites found
+  if ("${SUITES}" STREQUAL "")
+    message(FATAL_ERROR "No suites found to compile for static CCPP")
+  endif("${SUITES}" STREQUAL "")
+  # Remove trailing comma from list of suites
+  string(REGEX REPLACE "(.+),$" "\\1" SUITES ${SUITES})
+  # Run CCPP prebuild.py
+  message (STATUS "Running ccpp_prebuild.py for static CCPP")
+  execute_process(
+    COMMAND ccpp/framework/scripts/ccpp_prebuild.py --config=ccpp/config/ccpp_prebuild_config.py --static --suites=${SUITES} --builddir=${CMAKE_CURRENT_BINARY_DIR}/..
+    OUTPUT_FILE ${PROJECT_BINARY_DIR}/ccpp_prebuild.out
+    ERROR_FILE ${PROJECT_BINARY_DIR}/ccpp_prebuild.err
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    RESULT_VARIABLE return_code
+  )
+else(STATIC)
+  # Run CCPP prebuild.py
+  message (STATUS "Running ccpp_prebuild.py for dynamic CCPP")
+  execute_process(
+    COMMAND ccpp/framework/scripts/ccpp_prebuild.py --config=ccpp/config/ccpp_prebuild_config.py --builddir=${CMAKE_CURRENT_BINARY_DIR}/..
+    OUTPUT_FILE ${PROJECT_BINARY_DIR}/ccpp_prebuild.out
+    ERROR_FILE ${PROJECT_BINARY_DIR}/ccpp_prebuild.err
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    RESULT_VARIABLE return_code
+  )
+endif(STATIC)
+# Check return code from CCPP prebuild.py
+if(return_code EQUAL 0)
+  message (STATUS "CCPP prebuild step completed successfully")
+else(return_code EQUAL 0)
+  message (FATAL_ERROR "CCPP prebuild step failed, check ccpp_prebuild.out/ccpp_prebuild.err")
+endif(return_code EQUAL 0)
+####################################################################
+# End CCPP prebuild step                                           #
+####################################################################
+
 ENABLE_LANGUAGE(Fortran)
 
 include(CMakeForceCompiler)
@@ -8,14 +63,14 @@ include(CMakeForceCompiler)
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 IF(DEFINED ENV{NETCDF})
-  MESSAGE("The NETCDF env. variable is $ENV{NETCDF}")
+  MESSAGE(STATUS "The NETCDF environment variable is $ENV{NETCDF}")
   SET(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} $ENV{NETCDF})
 ELSE(DEFINED ENV{NETCDF})
   MESSAGE(FATAL_ERROR "The NETCDF environement variable must be set to point to your NetCDF installation before building. Stopping...")
 ENDIF(DEFINED ENV{NETCDF})
 
 IF(DEFINED ENV{NCEPLIBS_DIR})
-  MESSAGE("The NCEPLIBS_DIR env. variable is $ENV{NCEPLIBS_DIR}")
+  MESSAGE(STATUS "The NCEPLIBS_DIR environment variable is $ENV{NCEPLIBS_DIR}")
   set(NCEPLIBS_DIR $ENV{NCEPLIBS_DIR})
 ELSE(DEFINED ENV{NCEPLIBS_DIR})
   MESSAGE(FATAL_ERROR "The NCEPLIBS_DIR environment variable must be set to point to your NCEPlibs installation before building. Stopping...")


### PR DESCRIPTION
This PR

- Updates the submodule pointer for ccpp/physics to fix the broken dtc/develop branch (following PR https://github.com/NCAR/gmtb-scm/pull/141 which didn't update the submodule pointer).
- Runs `ccpp_prebuild.py` as part of the cmake step for both the dynamic and static CCPP. For the static build, a list of all suites is generated from the suites directory and compiled into the executable.

This code was tested successfully on
- hera+intel in "Release" mode
- cheyenne+gnu in "Release" mode
- macos+clang/gfortran in "Release" mode (build/compile only)
for both dynamic and static CCPP.

**Warning** The SCM code is currently broken in "Debug" mode:
- For the Intel compiler, the compilation step fails because of mismatching arguments in `ugwp_driver_v0.F` (see known issue https://github.com/NCAR/ccpp-physics/pull/354).
- For the GNU compiler, the runs segfault in `sfc_nst.f`, line 384. See the comment below for the full stacktrace.
- on macos+clang/gfortran, the code crashes in both "Release" and "Debug" mode with `Segmentation fault - invalid memory reference` right at the beginning.

This PR is **not** addressing these issues.