### PR TITLE
fix CMakeLists.txt to work with older default version on Hera

### DIFF
--- a/scm/src/CMakeLists.txt
+++ b/scm/src/CMakeLists.txt
@@ -17,7 +17,7 @@ if(STATIC)
   foreach(suite_definition_filepath IN LISTS SUITE_DEFINITION_FILES)
     get_filename_component(suite_definition_filename ${suite_definition_filepath} NAME)
     string(REGEX REPLACE "^suite_(.+)\\.xml$" "\\1" suite_name ${suite_definition_filename})
-    string(APPEND SUITES "${suite_name},")
+    set(SUITES ${SUITES}${suite_name},)
     message (STATUS "  adding suite ${suite_name}")
   endforeach(suite_definition_filepath IN LISTS SUITE_DEFINITION_FILES)
   # Abort if no suites found


### PR DESCRIPTION
-replace string append operation in CMakeLists.txt with different syntax to work with older versions of cmake
-from what I can tell, STRING(APPEND) first appeared in version 3.4.

followup to PR #142 

tested to work on Hera/Intel with default cmake and Mac OS

