### PR TITLE
dtc/develop: update submodule pointer ccpp physics 2019/11/25

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "ccpp-framework"]
 	path = ccpp/framework
 	url = https://github.com/NCAR/ccpp-framework
+	branch = dtc/develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
 	url = https://github.com/NCAR/ccpp-physics
+	branch = dtc/develop


### PR DESCRIPTION
- update submodule pointer for ccpp-physics following the merge of https://github.com/NCAR/ccpp-physics/pull/354.
- update .gitmodules to point to the correct branches dtc/develop for the submodules (so that `git submodule update --remote` works as intended)

No testing required, will merge immediately.