### PR TITLE
update for adding Ferrier-Aligo MP

### DIFF
--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -91,6 +91,7 @@ SCHEME_FILES_DEPENDENCIES = [
     'ccpp/physics/physics/module_mp_radar.F90',
     'ccpp/physics/physics/module_mp_thompson.F90',
     'ccpp/physics/physics/module_mp_thompson_make_number_concentrations.F90',
+    'ccpp/physics/physics/module_MP_FER_HIRES.F90',
     'ccpp/physics/physics/module_bl_mynn.F90',
     'ccpp/physics/physics/module_sf_mynn.F90',
     'ccpp/physics/physics/module_SF_JSFC.F90',
@@ -231,8 +232,13 @@ SCHEME_FILES = {
     'ccpp/physics/physics/sfc_nst.f'                        : ['physics'],
     'ccpp/physics/physics/sfc_ocean.F'                      : ['physics'],
     'ccpp/physics/physics/sfc_sice.f'                       : ['physics'],
+    'ccpp/physics/physics/mp_fer_hires.F90'                 : ['physics'],
     'ccpp/physics/physics/gmtb_scm_sfc_flux_spec.F90'       : ['physics'],
     }
+
+# Default build dir, relative to current working directory,
+# if not specified as command-line argument
+DEFAULT_BUILD_DIR = 'scm/bin'
 
 # Auto-generated makefile/cmakefile snippets that contain all schemes
 SCHEMES_MAKEFILE = 'ccpp/physics/CCPP_SCHEMES.mk'
@@ -314,6 +320,13 @@ OPTIONAL_ARGUMENTS = {
             'ice_friendly_aerosol_number_concentration_updated_by_physics',
             'tendency_of_water_friendly_aerosols_at_surface',
             'tendency_of_ice_friendly_aerosols_at_surface',
+            ],
+        },
+    'mp_fer_hires' : {
+        'mp_fer_hires_init' : [
+            'fraction_of_ice_water_cloud',
+            'fraction_of_rain_water_cloud',
+            'rime_factor',
             ],
         },
     #'subroutine_name_1' : 'all',

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -368,6 +368,13 @@
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
+[gq0(:,:,index_for_mass_weighted_rime_factor)]
+  standard_name = mass_weighted_rime_factor_updated_by_physics
+  long_name = mass weighted rime factor updated by physics
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 [gq0(:,:,index_for_water_friendly_aerosols)]
   standard_name = water_friendly_aerosol_number_concentration_updated_by_physics
   long_name = number concentration of water-friendly aerosols updated by physics
@@ -2176,6 +2183,12 @@
   units = flag
   dimensions = ()
   type = integer
+[imp_physics_fer_hires]
+  standard_name = flag_for_fer_hires_microphysics_scheme
+  long_name = choice of Ferrier-Aligo microphysics scheme
+  units = flag
+  dimensions = ()
+  type = integer
 [imp_physics_gfdl]
   standard_name = flag_for_gfdl_microphysics_scheme
   long_name = choice of GFDL microphysics scheme
@@ -2557,6 +2570,12 @@
   units = count
   dimensions = ()
   type = integer
+[rdlai]
+  standard_name = flag_for_reading_leaf_area_index_from_input
+  long_name = flag for reading leaf area index from initial conditions for RUC LSM
+  units = flag
+  dimensions = ()
+  type = logical
 [ivegsrc]
   standard_name = vegetation_type_dataset_choice
   long_name = land use dataset choice
@@ -2569,6 +2588,19 @@
   units = index
   dimensions = ()
   type = integer
+[spec_adv]
+  standard_name = flag_for_individual_cloud_species_advected 
+  long_name = flag for individual cloud species advected
+  units = flag 
+  dimensions = ()
+  type = logical
+[flgmin]
+  standard_name = minimum_large_ice_fraction
+  long_name = minimum large ice fraction in F-A mp scheme
+  units = frac
+  dimensions = (2)
+  type = real
+  kind = kind_phys
 [iopt_dveg]
   standard_name = flag_for_dynamic_vegetation_option
   long_name = choice for dynamic vegetation option (see noahmp module for definition)
@@ -2653,6 +2685,13 @@
   units = flag
   dimensions = ()
   type = logical
+[rhgrd]
+  standard_name = fa_threshold_relative_humidity_for_onset_of_condensation
+  long_name = relative humidity threshold parameter for condensation for FA scheme
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [flipv]
   standard_name = flag_flip
   long_name = vertical flip logical
@@ -3429,6 +3468,12 @@
 [ntke]
   standard_name = index_for_turbulent_kinetic_energy
   long_name = tracer index for turbulent kinetic energy
+  units = index
+  dimensions = ()
+  type = integer
+[nqrimef]
+  standard_name = index_for_mass_weighted_rime_factor
+  long_name = tracer index for mass weighted rime factor
   units = index
   dimensions = ()
   type = integer
@@ -4861,6 +4906,13 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[train]
+  standard_name = accumulated_change_of_air_temperature_due_to_FA_scheme
+  long_name = accumulated change of air temperature due to FA MP scheme
+  units = K
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 [gflux]
   standard_name = cumulative_surface_ground_heat_flux_multiplied_by_timestep
   long_name = cumulative groud conductive heat flux multiplied by timestep
@@ -5771,6 +5823,76 @@
 [ccpp-arg-table]
   name = GFS_interstitial_type
   type = ddt
+[qv_r]
+  standard_name = humidity_mixing_ratio
+  long_name = the ratio of the mass of water vapor to the mass of dry air
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[qc_r]
+  standard_name = cloud_liquid_water_mixing_ratio
+  long_name = the ratio of the mass of liquid water to the mass of dry air
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[qr_r]
+  standard_name = cloud_rain_water_mixing_ratio
+  long_name = the ratio of the mass rain water to the mass of dry air
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[qi_r]
+  standard_name = cloud_ice_mixing_ratio
+  long_name = the ratio of the mass of ice to the mass of dry air
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[qs_r]
+  standard_name = cloud_snow_mixing_ratio
+  long_name = the ratio of the mass of snow to mass of dry air
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[qg_r]
+  standard_name = mass_weighted_rime_factor_mixing_ratio
+  long_name = the ratio of the mass of rime factor to mass of dry air
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[f_ice]
+  standard_name = fraction_of_ice_water_cloud
+  long_name = fraction of ice water cloud
+  units = frac
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[f_rain]
+  standard_name = fraction_of_rain_water_cloud
+  long_name = fraction of rain water cloud
+  units = frac
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[f_rimef]
+  standard_name = rime_factor
+  long_name = rime factor
+  units = frac
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[cwm]
+  standard_name = total_cloud_condensate_mixing_ratio_updated_by_physics
+  long_name = total cloud condensate mixing ratio (except water vapor) updated by physics
+  units = kg kg-1
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
 [adjsfculw_ocean]
   standard_name = surface_upwelling_longwave_flux_over_ocean_interstitial
   long_name = surface upwelling longwave flux at current time over ocean (temporary use as interstitial)
@@ -7236,7 +7358,7 @@
   type = integer
 [ntiwx]
   standard_name = index_for_ice_cloud_condensate_vertical_diffusion_tracer
-  long_name = index for ice cloud condensate n the vertically diffused tracer array
+  long_name = index for ice cloud condensate in the vertically diffused tracer array
   units = index
   dimensions = ()
   type = integer

--- a/scm/src/gmtb_scm_physical_constants.f90
+++ b/scm/src/gmtb_scm_physical_constants.f90
@@ -24,7 +24,7 @@ public
   real(kind=dp),parameter:: con_hfus   =3.3358e+5
   real(kind=dp),parameter:: con_t0c    =2.7315e+2
   real(kind=dp),parameter:: con_ttp    =2.7316e+2
-
+  real(kind=dp),parameter:: con_epsq   =1.0E-12_dp
 
   real(kind=dp),parameter:: con_rocp   =con_rd/con_cp
   real(kind=dp),parameter:: con_fvirt  =con_rv/con_rd - 1

--- a/scm/src/gmtb_scm_physical_constants.meta
+++ b/scm/src/gmtb_scm_physical_constants.meta
@@ -99,6 +99,13 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[con_epsq]
+  standard_name = minimum_value_of_specific_humidity
+  long_name = floor value for specific humidity
+  units = kg kg-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [con_vonKarman]
   standard_name = vonKarman_constant
   long_name = vonKarman constant

--- a/scm/src/gmtb_scm_type_defs.f90
+++ b/scm/src/gmtb_scm_type_defs.f90
@@ -76,6 +76,7 @@ module gmtb_scm_type_defs
     integer                           :: tke_index !< index for TKE in the tracer array
     integer                           :: water_friendly_aerosol_index !< index for water-friendly aerosols in the tracer array
     integer                           :: ice_friendly_aerosol_index !< index for ice-friendly aerosols in the tracer array
+    integer                           :: mass_weighted_rime_factor_index !< index for mass-weighted rime factor
     integer                           :: init_year, init_month, init_day, init_hour
     character(len=32), allocatable    :: tracer_names(:) !< name of physics suite (must be "GFS_operational" for prototype)
     integer, allocatable              :: blksz(:)
@@ -374,7 +375,7 @@ module gmtb_scm_type_defs
     scm_state%n_cols = n_columns
     scm_state%n_timesteps = int_zero
     scm_state%n_time_levels = n_time_levels
-    scm_state%n_tracers = 16
+    scm_state%n_tracers = 17
     allocate(scm_state%tracer_names(scm_state%n_tracers))
     scm_state%water_vapor_index = 1
     scm_state%ozone_index = 2
@@ -392,6 +393,7 @@ module gmtb_scm_type_defs
     scm_state%tke_index = 14
     scm_state%water_friendly_aerosol_index = 15
     scm_state%ice_friendly_aerosol_index = 16
+    scm_state%mass_weighted_rime_factor_index = 17
     scm_state%tracer_names(1) = 'vap_wat'
     scm_state%tracer_names(2) = 'o3mr'
     scm_state%tracer_names(3) = 'liq_wat'
@@ -408,6 +410,7 @@ module gmtb_scm_type_defs
     scm_state%tracer_names(14)= 'sgs_tke'
     scm_state%tracer_names(15)= 'liq_aero'
     scm_state%tracer_names(16)= 'ice_aero'
+    scm_state%tracer_names(17)= 'q_rimef'
     scm_state%n_itt_swrad = int_zero
     scm_state%n_itt_lwrad = int_zero
     scm_state%n_itt_out = int_zero


### PR DESCRIPTION
- added new files to CCPP prebuild configuration
- mirrored changes to GFS_typedefs.[F90,meta] from https://github.com/NCAR/fv3atm/pull/2 and https://github.com/NCAR/fv3atm/pull/10

Note: No SDF or namelist for F-A added in this PR (this PR is for fixing the build only!)