### PR TITLE
Fix noahmp precip rates

### DIFF
--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -227,7 +227,6 @@ SCHEME_FILES = {
     'ccpp/physics/physics/sfc_cice.f'                       : ['physics'],
     'ccpp/physics/physics/sfc_diff.f'                       : ['physics'],
     'ccpp/physics/physics/sfc_drv.f'                        : ['physics'],
-    'ccpp/physics/physics/sfc_noahmp_pre.F90'               : ['physics'],
     'ccpp/physics/physics/sfc_noahmp_drv.f'                 : ['physics'],
     'ccpp/physics/physics/sfc_nst.f'                        : ['physics'],
     'ccpp/physics/physics/sfc_ocean.F'                      : ['physics'],

--- a/ccpp/suites/suite_SCM_GFS_v15_noahmp.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15_noahmp.xml
@@ -42,7 +42,6 @@
       <scheme>sfc_nst_pre</scheme>
       <scheme>sfc_nst</scheme>
       <scheme>sfc_nst_post</scheme>
-      <scheme>sfc_noahmp_pre</scheme>
       <scheme>noahmpdrv</scheme>
       <scheme>sfc_sice</scheme>
       <scheme>GFS_surface_loop_control_part2</scheme>

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -4558,7 +4558,7 @@ module GFS_typedefs
        Tbd%cactiv = zero
     end if
 
-   if (Model%lsm == Model%lsm_ruc) then
+   if (Model%lsm == Model%lsm_ruc .or. Model%lsm == Model%lsm_noahmp) then
        allocate(Tbd%raincprv  (IM))
        allocate(Tbd%rainncprv (IM))
        allocate(Tbd%iceprv    (IM))

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -351,7 +351,21 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: chs2(:)          => null()  !exch coeff for heat at 2m
     real (kind=kind_phys), pointer :: cqs2(:)          => null()  !exch coeff for moisture at 2m
     real (kind=kind_phys), pointer :: lh(:)            => null()  !latent heating at the surface
+    
+    !---- precipitation amounts from previous time step for RUC LSM
+    real (kind=kind_phys), pointer :: raincprv  (:)    => null()  !< explicit rainfall from previous timestep
+    real (kind=kind_phys), pointer :: rainncprv (:)    => null()  !< convective_precipitation_amount from previous timestep
+    real (kind=kind_phys), pointer :: iceprv    (:)    => null()  !< ice amount from previous timestep
+    real (kind=kind_phys), pointer :: snowprv   (:)    => null()  !< snow amount from previous timestep
+    real (kind=kind_phys), pointer :: graupelprv(:)    => null()  !< graupel amount from previous timestep
 
+    !---- precipitation rates from previous time step for NoahMP LSM
+    real (kind=kind_phys), pointer :: draincprv  (:)    => null()  !< convective precipitation rate from previous timestep
+    real (kind=kind_phys), pointer :: drainncprv (:)    => null()  !< explicit rainfall rate from previous timestep
+    real (kind=kind_phys), pointer :: diceprv    (:)    => null()  !< ice precipitation rate from previous timestep
+    real (kind=kind_phys), pointer :: dsnowprv   (:)    => null()  !< snow precipitation rate from previous timestep
+    real (kind=kind_phys), pointer :: dgraupelprv(:)    => null()  !< graupel precipitation rate from previous timestep
+    
     contains
       procedure :: create  => sfcprop_create  !<   allocate array data
   end type GFS_sfcprop_type
@@ -1121,20 +1135,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: prevst (:,:)     => null()  !<
     real (kind=kind_phys), pointer :: prevsq (:,:)     => null()  !<
     integer,               pointer :: cactiv   (:)     => null()  !< convective activity memory contour
-    
-    !---- precipitation amounts from previous time step for RUC LSM
-    real (kind=kind_phys), pointer :: raincprv  (:)    => null()  !< explicit rainfall from previous timestep
-    real (kind=kind_phys), pointer :: rainncprv (:)    => null()  !< convective_precipitation_amount from previous timestep
-    real (kind=kind_phys), pointer :: iceprv    (:)    => null()  !< ice amount from previous timestep
-    real (kind=kind_phys), pointer :: snowprv   (:)    => null()  !< snow amount from previous timestep
-    real (kind=kind_phys), pointer :: graupelprv(:)    => null()  !< graupel amount from previous timestep
-
-    !---- precipitation rates from previous time step for NoahMP LSM
-    real (kind=kind_phys), pointer :: draincprv  (:)    => null()  !< convective precipitation rate from previous timestep
-    real (kind=kind_phys), pointer :: drainncprv (:)    => null()  !< explicit rainfall rate from previous timestep
-    real (kind=kind_phys), pointer :: diceprv    (:)    => null()  !< ice precipitation rate from previous timestep
-    real (kind=kind_phys), pointer :: dsnowprv   (:)    => null()  !< snow precipitation rate from previous timestep
-    real (kind=kind_phys), pointer :: dgraupelprv(:)    => null()  !< graupel precipitation rate from previous timestep
 
     !--- MYNN prognostic variables that can't be in the Intdiag or Interstitial DDTs
     real (kind=kind_phys), pointer :: CLDFRA_BL  (:,:)   => null()  !
@@ -2108,7 +2108,19 @@ module GFS_typedefs
       Sfcprop%dt_cool = zero
       Sfcprop%qrain   = zero
     endif
-
+    
+    if (Model%lsm == Model%lsm_ruc .or. Model%lsm == Model%lsm_noahmp) then
+        allocate(Sfcprop%raincprv  (IM))
+        allocate(Sfcprop%rainncprv (IM))
+        allocate(Sfcprop%iceprv    (IM))
+        allocate(Sfcprop%snowprv   (IM))
+        allocate(Sfcprop%graupelprv(IM))
+        Sfcprop%raincprv   = clear_val
+        Sfcprop%rainncprv  = clear_val
+        Sfcprop%iceprv     = clear_val
+        Sfcprop%snowprv    = clear_val
+        Sfcprop%graupelprv = clear_val
+     end if
 ! Noah MP allocate and init when used
 !
     if (Model%lsm == Model%lsm_noahmp ) then
@@ -2183,7 +2195,19 @@ module GFS_typedefs
     Sfcprop%tsnoxy     = clear_val
     Sfcprop%smoiseq    = clear_val
     Sfcprop%zsnsoxy    = clear_val
-
+    
+    allocate(Sfcprop%draincprv  (IM))
+    allocate(Sfcprop%drainncprv (IM))
+    allocate(Sfcprop%diceprv    (IM))
+    allocate(Sfcprop%dsnowprv   (IM))
+    allocate(Sfcprop%dgraupelprv(IM))
+    
+    Sfcprop%draincprv   = clear_val
+    Sfcprop%drainncprv  = clear_val
+    Sfcprop%diceprv     = clear_val
+    Sfcprop%dsnowprv    = clear_val
+    Sfcprop%dgraupelprv = clear_val
+    
    endif
 
     if (Model%lsm == Model%lsm_ruc) then
@@ -4556,32 +4580,6 @@ module GFS_typedefs
     if (Model%imfdeepcnv == Model%imfdeepcnv_gf) then
        allocate(Tbd%cactiv(IM))
        Tbd%cactiv = zero
-    end if
-
-   if (Model%lsm == Model%lsm_ruc .or. Model%lsm == Model%lsm_noahmp) then
-       allocate(Tbd%raincprv  (IM))
-       allocate(Tbd%rainncprv (IM))
-       allocate(Tbd%iceprv    (IM))
-       allocate(Tbd%snowprv   (IM))
-       allocate(Tbd%graupelprv(IM))
-       Tbd%raincprv   = clear_val
-       Tbd%rainncprv  = clear_val
-       Tbd%iceprv     = clear_val
-       Tbd%snowprv    = clear_val
-       Tbd%graupelprv = clear_val
-    end if
-
-    if (Model%lsm == Model%lsm_noahmp) then
-        allocate(Tbd%draincprv  (IM))
-        allocate(Tbd%drainncprv (IM))
-        allocate(Tbd%diceprv    (IM))
-        allocate(Tbd%dsnowprv   (IM))
-        allocate(Tbd%dgraupelprv(IM))
-        Tbd%draincprv   = clear_val
-        Tbd%drainncprv  = clear_val
-        Tbd%diceprv     = clear_val
-        Tbd%dsnowprv    = clear_val
-        Tbd%dgraupelprv = clear_val
     end if
 
     !--- MYNN variables:

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -1283,6 +1283,76 @@
   dimensions = (horizontal_dimension)
   type = real
   kind = kind_phys
+[raincprv]
+  standard_name = lwe_thickness_of_convective_precipitation_amount_from_previous_timestep
+  long_name = convective_precipitation_amount from previous timestep
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[rainncprv]
+  standard_name = lwe_thickness_of_explicit_rainfall_amount_from_previous_timestep
+  long_name = explicit rainfall from previous timestep
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[iceprv]
+  standard_name = lwe_thickness_of_ice_amount_from_previous_timestep
+  long_name = ice amount from previous timestep
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[snowprv]
+  standard_name = lwe_thickness_of_snow_amount_from_previous_timestep
+  long_name = snow amount from previous timestep
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[graupelprv]
+  standard_name = lwe_thickness_of_graupel_amount_from_previous_timestep
+  long_name = graupel amount from previous timestep
+  units = m
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[draincprv]
+  standard_name = convective_precipitation_rate_from_previous_timestep
+  long_name = convective precipitation rate from previous timestep
+  units = mm s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[drainncprv]
+  standard_name = explicit_rainfall_rate_from_previous_timestep
+  long_name = explicit rainfall rate previous timestep
+  units = mm s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[diceprv]
+  standard_name = ice_precipitation_rate_from_previous_timestep
+  long_name = ice precipitation rate from previous timestep
+  units = mm s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[dsnowprv]
+  standard_name = snow_precipitation_rate_from_previous_timestep
+  long_name = snow precipitation rate from previous timestep
+  units = mm s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
+[dgraupelprv]
+  standard_name = graupel_precipitation_rate_from_previous_timestep
+  long_name = graupel precipitation rate from previous timestep
+  units = mm s-1
+  dimensions = (horizontal_dimension)
+  type = real
+  kind = kind_phys
 
 ########################################################################
 [ccpp-arg-table]
@@ -4300,76 +4370,6 @@
   units = none
   dimensions = (horizontal_dimension)
   type = integer
-[raincprv]
-  standard_name = lwe_thickness_of_convective_precipitation_amount_from_previous_timestep
-  long_name = convective_precipitation_amount from previous timestep
-  units = m
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[rainncprv]
-  standard_name = lwe_thickness_of_explicit_rainfall_amount_from_previous_timestep
-  long_name = explicit rainfall from previous timestep
-  units = m
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[iceprv]
-  standard_name = lwe_thickness_of_ice_amount_from_previous_timestep
-  long_name = ice amount from previous timestep
-  units = m
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[snowprv]
-  standard_name = lwe_thickness_of_snow_amount_from_previous_timestep
-  long_name = snow amount from previous timestep
-  units = m
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[graupelprv]
-  standard_name = lwe_thickness_of_graupel_amount_from_previous_timestep
-  long_name = graupel amount from previous timestep
-  units = m
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[draincprv]
-  standard_name = convective_precipitation_rate_from_previous_timestep
-  long_name = convective precipitation rate from previous timestep
-  units = mm s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[drainncprv]
-  standard_name = explicit_rainfall_rate_from_previous_timestep
-  long_name = explicit rainfall rate previous timestep
-  units = mm s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[diceprv]
-  standard_name = ice_precipitation_rate_from_previous_timestep
-  long_name = ice precipitation rate from previous timestep
-  units = mm s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[dsnowprv]
-  standard_name = snow_precipitation_rate_from_previous_timestep
-  long_name = snow precipitation rate from previous timestep
-  units = mm s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
-[dgraupelprv]
-  standard_name = graupel_precipitation_rate_from_previous_timestep
-  long_name = graupel precipitation rate from previous timestep
-  units = mm s-1
-  dimensions = (horizontal_dimension)
-  type = real
-  kind = kind_phys
 [CLDFRA_BL]
   standard_name = subgrid_cloud_fraction_pbl
   long_name = subgrid cloud fraction from PBL scheme


### PR DESCRIPTION
Since NoahMP precipitation rate calculation was moved to GFS_MP_generic_post_run, sfc_noahmp_pre is no longer needed, so it is deleted from the CCPP configuration file and SDFs. Also, precipitation rate variables used in RUC LSM and NoahMP LSM are put in the Sfcprop DDT rather than the catch-all TBD DDT.