### PR TITLE
Fix Hera plotting

### DIFF
--- a/scm/etc/scripts/gmtb_scm_analysis.py
+++ b/scm/etc/scripts/gmtb_scm_analysis.py
@@ -18,12 +18,15 @@ Rd = 287.0
 Rv = 461.0
 g = 9.81
 
-plot_ext = '.png' #.pdf, .eps, .ps, .png (.png is fastest, but raster)
+plot_ext = '.pdf' #.pdf, .eps, .ps, .png (.png is fastest, but raster)
 
 reload(gspr)
 reload(gsro)
 
-pd.plotting.register_matplotlib_converters()
+try:
+  pd.plotting.register_matplotlib_converters()
+except (AttributeError):
+  print "Warning: The version of the pandas package you are using may lead to Future Warnings being generated. These can be ignored for now." 
 
 #subroutine for printing progress to the command line
 def print_progress(n_complete, n_total):


### PR DESCRIPTION
Hera uses an older version of the Pandas package where the following line causes an error:
`pandas.plotting.register_matplotlib_converters()`

This line was added because not having it there with newer versions of Pandas leads to a "Future Warning". This was put in a try block.

Also, it appears that Hera doesn't have dvipng installed, which is needed to render LaTeX in plots and save as a PNG file. The file format has been changed back to using PDF instead.

Note: This should be merged after the short course since instructions mention PNG, and the AMI has no problem with plotting PNGs.