### PR TITLE
Dockerfile update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,28 +11,13 @@ MAINTAINER Michelle Harrold <harrold@ucar.edu> or Grant Firl <grantf@ucar.edu>
 
 # Obtain CCPP SCM source code
 RUN cd /comsoftware \
-  && git clone --recursive -b release/public-v4 https://github.com/NCAR/gmtb-scm
+  && git clone --recursive -b v4.0.0beta01 https://github.com/NCAR/gmtb-scm
 
 # Obtain the pre-computed look-up tables for running with Thompson microphysics
 RUN cd /comsoftware/gmtb-scm/scm/data/physics_input_data \
   && curl -L -O https://dtcenter.org/GMTB/freezeH2O.dat \
   && curl -L -O https://dtcenter.org/GMTB/qr_acr_qg.dat \
   && curl -L -O https://dtcenter.org/GMTB/qr_acr_qs.dat
-
-# Upgrade cmake for NCEPLIBS
-RUN cd /comsoftware/gmtb-scm/ \
-  && mkdir -p cmake \
-  && source /opt/rh/devtoolset-8/enable \
-  && curl -L -O https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5.tar.gz \
-  && tar -xf cmake-3.16.5.tar.gz \
-  && cd cmake-3.16.5 \
-  && cmake -DCMAKE_USE_OPENSSL=OFF -DCMAKE_INSTALL_PREFIX=/comsoftware/gmtb-scm/cmake  . \
-  && make install \
-  && cd / \ 
-  && rm -rfd /comsoftware/gmtb-scm/cmake-3.16.5 \
-  && rm -rfd /comsoftware/gmtb-scm/cmake-3.16.5-tar-gz
-
-ENV PATH /comsoftware/gmtb-scm/cmake/bin:$PATH
 
 # Run the machine setup script to set environment variables
 RUN cd /comsoftware/gmtb-scm/scm/ \


### PR DESCRIPTION
remove cmake installation in Dockerfile since base image now has cmake that is new enough for NCEPLIBS; point to tag instead of branch for gmtb-scm

Will need one more update when tag v4.0.0 is actually ready.