### PR TITLE
update SCM to work with ccpp-physics master (8/31/2020)

### DIFF
--- a/ccpp/physics_namelists/input_GFS_v15p2.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2.nml
@@ -46,7 +46,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v15p2_ACM.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_ACM.nml
@@ -48,7 +48,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v15p2_FA.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_FA.nml
@@ -48,7 +48,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v15p2_MYJ.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_MYJ.nml
@@ -48,7 +48,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP.nml
@@ -46,7 +46,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
        do_RRTMGP      = .true.
        active_gases   = 'h2o_co2_o3_n2o_ch4_o2'
        ngases         = 6

--- a/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP_LWjac.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP_LWjac.nml
@@ -46,7 +46,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
        do_RRTMGP      = .true.
        active_gases   = 'h2o_co2_o3_n2o_ch4_o2'
        ngases         = 6

--- a/ccpp/physics_namelists/input_GFS_v15p2_YSU.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_YSU.nml
@@ -47,7 +47,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v15p2_noahmp.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_noahmp.nml
@@ -47,7 +47,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v15p2_saYSU.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_saYSU.nml
@@ -47,7 +47,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v16beta.nml
+++ b/ccpp/physics_namelists/input_GFS_v16beta.nml
@@ -69,7 +69,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
 /
 
 &gfdl_cloud_microphysics_nml

--- a/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP.nml
+++ b/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP.nml
@@ -69,7 +69,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
        do_RRTMGP      = .true.
        active_gases   = 'h2o_co2_o3_n2o_ch4_o2'
        ngases         = 6

--- a/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP_LWjac.nml
+++ b/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP_LWjac.nml
@@ -69,7 +69,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
        do_RRTMGP      = .true.
        active_gases   = 'h2o_co2_o3_n2o_ch4_o2'
        ngases         = 6

--- a/ccpp/physics_namelists/input_GSD_v1.nml
+++ b/ccpp/physics_namelists/input_GSD_v1.nml
@@ -53,7 +53,6 @@
        do_sppt        = .false.
        do_shum        = .false.
        do_skeb        = .false.
-       do_sfcperts    = .false.
        lsm            = 3
        lsoil_lsm      = 9
        iopt_dveg      = 2

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -491,7 +491,6 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: skebu_wts (:,:) => null()  !
     real (kind=kind_phys), pointer :: skebv_wts (:,:) => null()  !
     real (kind=kind_phys), pointer :: sfc_wts   (:,:) => null()  ! mg, sfc-perts
-    integer              :: nsfcpert=6                             !< number of sfc perturbations
 
     !--- aerosol surface emissions for Thompson microphysics
     real (kind=kind_phys), pointer :: nwfa2d  (:)     => null()  !< instantaneous water-friendly sfc aerosol source
@@ -1015,14 +1014,14 @@ module GFS_typedefs
     logical              :: do_shum
     logical              :: do_skeb
     integer              :: skeb_npass
-    logical              :: do_sfcperts
-    integer              :: nsfcpert=6
-    real(kind=kind_phys) :: pertz0(5)          ! mg, sfc-perts
-    real(kind=kind_phys) :: pertzt(5)          ! mg, sfc-perts
-    real(kind=kind_phys) :: pertshc(5)         ! mg, sfc-perts
-    real(kind=kind_phys) :: pertlai(5)         ! mg, sfc-perts
-    real(kind=kind_phys) :: pertalb(5)         ! mg, sfc-perts
-    real(kind=kind_phys) :: pertvegf(5)        ! mg, sfc-perts
+    integer              :: lndp_type
+    integer              :: n_var_lndp
+    character(len=3)     :: lndp_var_list(6)  ! dimension here must match  n_var_max_lndp in  stochy_nml_def
+    real(kind=kind_phys) :: lndp_prt_list(6)  ! dimension here must match  n_var_max_lndp in  stochy_nml_def 
+                                              ! also previous code had dimension 5 for each pert, to allow 
+                                              ! multiple patterns. It wasn't fully coded (and wouldn't have worked 
+                                              ! with nlndp>1, so I just dropped it). If we want to code it properly, 
+                                              ! we'd need to make this dim(6,5).
 !--- tracer handling
     character(len=32), pointer :: tracer_names(:) !< array of initialized tracers from dynamic core
     integer              :: ntrac           !< number of tracers
@@ -1495,7 +1494,9 @@ module GFS_typedefs
     real (kind=kind_phys), pointer :: cldcov (:,:)   => null()  !< instantaneous 3D cloud fraction
 !--- F-A MP scheme
     real (kind=kind_phys), pointer :: TRAIN  (:,:)   => null()  !< accumulated stratiform T tendency (K s-1)
-
+    
+    real (kind=kind_phys), pointer :: cldfra  (:,:)   => null()  !< instantaneous 3D cloud
+    
     !--- MP quantities for 3D diagnositics 
     real (kind=kind_phys), pointer :: refl_10cm(:,:) => null()  !< instantaneous refl_10cm
 !
@@ -1915,6 +1916,8 @@ module GFS_typedefs
     real (kind=kind_phys), pointer      :: uustar_ocean(:)    => null()  !<
     real (kind=kind_phys), pointer      :: vdftra(:,:,:)      => null()  !<
     real (kind=kind_phys), pointer      :: vegf1d(:)          => null()  !<
+    real (kind=kind_phys)               :: lndp_vgf                      !<
+  
     integer, pointer                    :: vegtype(:)         => null()  !<
     real (kind=kind_phys), pointer      :: w_upi(:,:)         => null()  !<
     real (kind=kind_phys), pointer      :: wcbmax(:)          => null()  !<
@@ -2745,9 +2748,9 @@ module GFS_typedefs
       Coupling%skebv_wts = clear_val
     endif
 
-    !--- stochastic physics option
-    if (Model%do_sfcperts) then
-      allocate (Coupling%sfc_wts  (IM,Model%nsfcpert))
+    !--- stochastic land perturbation option
+    if (Model%lndp_type .NE. 0) then
+      allocate (Coupling%sfc_wts  (IM,Model%n_var_lndp))
       Coupling%sfc_wts = clear_val
     endif
 
@@ -3250,15 +3253,9 @@ module GFS_typedefs
     logical :: use_zmtnblck = .false.
     logical :: do_shum      = .false.
     logical :: do_skeb      = .false.
-    integer :: skeb_npass = 11
-    logical :: do_sfcperts = .false.   ! mg, sfc-perts
-    integer :: nsfcpert    =  6        ! mg, sfc-perts
-    real(kind=kind_phys) :: pertz0   = -999.
-    real(kind=kind_phys) :: pertzt   = -999.
-    real(kind=kind_phys) :: pertshc  = -999.
-    real(kind=kind_phys) :: pertlai  = -999.
-    real(kind=kind_phys) :: pertalb  = -999.
-    real(kind=kind_phys) :: pertvegf = -999.
+    integer :: skeb_npass   = 11
+    integer :: lndp_type    = 0 
+    integer :: n_var_lndp   =  0 
 
 !--- aerosol scavenging factors
     character(len=20) :: fscav_aero(20) = 'default'
@@ -3327,7 +3324,7 @@ module GFS_typedefs
                                do_deep, jcap,                                               &
                                cs_parm, flgmin, cgwf, ccwf, cdmbgwd, sup, ctei_rm, crtrh,   &
                                dlqf, rbcr, shoc_parm, psauras, prauras, wminras,            &
-                               do_sppt, do_shum, do_skeb, do_sfcperts,                      &
+                               do_sppt, do_shum, do_skeb, lndp_type,  n_var_lndp,           & 
                           !--- Rayleigh friction
                                prslrd0, ral_ts,  ldiag_ugwp, do_ugwp, do_tofd,              &
                           ! --- Ferrier-Aligo
@@ -3935,21 +3932,15 @@ module GFS_typedefs
     Model%e0fac            = e0fac
 
 !--- stochastic physics options
-    ! do_sppt, do_shum, do_skeb and do_sfcperts are namelist variables in group
+    ! do_sppt, do_shum, do_skeb and lndp_type are namelist variables in group
     ! physics that are parsed here and then compared in init_stochastic_physics
     ! to the stochastic physics namelist parametersto ensure consistency.
     Model%do_sppt          = do_sppt
     Model%use_zmtnblck     = use_zmtnblck
     Model%do_shum          = do_shum
     Model%do_skeb          = do_skeb
-    Model%do_sfcperts      = do_sfcperts ! mg, sfc-perts
-    Model%nsfcpert         = nsfcpert    ! mg, sfc-perts
-    Model%pertz0           = pertz0
-    Model%pertzt           = pertzt
-    Model%pertshc          = pertshc
-    Model%pertlai          = pertlai
-    Model%pertalb          = pertalb
-    Model%pertvegf         = pertvegf
+    Model%lndp_type        = lndp_type
+    Model%n_var_lndp       = n_var_lndp
 
     !--- cellular automata options
     Model%nca              = nca
@@ -4922,7 +4913,8 @@ module GFS_typedefs
       print *, ' do_sppt           : ', Model%do_sppt
       print *, ' do_shum           : ', Model%do_shum
       print *, ' do_skeb           : ', Model%do_skeb
-      print *, ' do_sfcperts       : ', Model%do_sfcperts
+      print *, ' lndp_type         : ', Model%lndp_type
+      print *, ' n_var_lndp         : ', Model%n_var_lndp
       print *, ' '
       print *, 'cellular automata'
       print *, ' nca               : ', Model%nca
@@ -5434,7 +5426,9 @@ module GFS_typedefs
     if (Model%imp_physics == Model%imp_physics_fer_hires) then
      allocate (Diag%TRAIN     (IM,Model%levs))
     end if
-
+    
+    allocate (Diag%cldfra     (IM,Model%levs))
+    
     allocate (Diag%ca_deep  (IM))
     allocate (Diag%ca_turb  (IM))
     allocate (Diag%ca_shal  (IM))
@@ -5746,6 +5740,8 @@ module GFS_typedefs
     if (Model%imp_physics == Model%imp_physics_fer_hires) then
       Diag%TRAIN      = zero
     end if
+
+    Diag%cldfra      = zero
 
     Diag%totprcpb   = zero
     Diag%cnvprcpb   = zero
@@ -6869,6 +6865,7 @@ module GFS_typedefs
     Interstitial%uustar_ocean    = huge
     Interstitial%vdftra          = clear_val
     Interstitial%vegf1d          = clear_val
+    Interstitial%lndp_vgf        = clear_val
     Interstitial%vegtype         = 0
     Interstitial%wcbmax          = clear_val
     Interstitial%weasd_ice       = huge

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -1928,7 +1928,7 @@
   standard_name = weights_for_stochastic_surface_physics_perturbation
   long_name = weights for stochastic surface physics perturbation
   units = none
-  dimensions = (horizontal_dimension,number_of_surface_perturbations)
+  dimensions = (horizontal_dimension,number_of_land_surface_variables_perturbed)
   type = real
   kind = kind_phys
 [dqdti]
@@ -3806,8 +3806,8 @@
   type = real
   kind = kind_phys
 [do_sppt]
-  standard_name = flag_for_stochastic_surface_physics_perturbations
-  long_name = flag for stochastic surface physics perturbations
+  standard_name = flag_for_stochastic_physics_perturbations
+  long_name = flag for stochastic physics perturbations
   units = flag
   dimensions = ()
   type = logical
@@ -3829,60 +3829,32 @@
   units = flag
   dimensions = ()
   type = logical
-[do_sfcperts]
-  standard_name = flag_for_stochastic_surface_perturbations
-  long_name = flag for stochastic surface perturbations option
-  units = flag
+[lndp_type]
+  standard_name = index_for_stochastic_land_surface_perturbation_type
+  long_name = index for stochastic land surface perturbations type
+  units = index
   dimensions = ()
-  type = logical
-[nsfcpert]
-  standard_name = number_of_surface_perturbations
-  long_name = number of surface perturbations
+  type = integer
+[n_var_lndp]
+  standard_name = number_of_land_surface_variables_perturbed
+  long_name = number of land surface variables perturbed
   units = count
   dimensions = ()
   type = integer
-[pertz0]
-  standard_name = magnitude_of_perturbation_of_momentum_roughness_length
-  long_name = magnitude of perturbation of momentum roughness length
-  units = frac
-  dimensions = (5)
+[lndp_prt_list]
+  standard_name =magnitude_of_perturbations_for_landperts
+  long_name = magnitude of perturbations for landperts
+  units = variable
+  dimensions = (number_of_land_surface_variables_perturbed) 
   type = real
   kind = kind_phys
-[pertzt]
-  standard_name = magnitude_of_perturbation_of_heat_to_momentum_roughness_length_ratio
-  long_name = magnitude of perturbation of heat to momentum roughness length ratio
-  units = frac
-  dimensions = (5)
-  type = real
-  kind = kind_phys
-[pertshc]
-  standard_name = magnitude_of_perturbation_of_soil_type_b_parameter
-  long_name = magnitude of perturbation of soil type b parameter
-  units = frac
-  dimensions = (5)
-  type = real
-  kind = kind_phys
-[pertlai]
-  standard_name = magnitude_of_perturbation_of_leaf_area_index
-  long_name = magnitude of perturbation of leaf area index
-  units = frac
-  dimensions = (5)
-  type = real
-  kind = kind_phys
-[pertalb]
-  standard_name = magnitude_of_surface_albedo_perturbation
-  long_name = magnitude of surface albedo perturbation
-  units = frac
-  dimensions = (5)
-  type = real
-  kind = kind_phys
-[pertvegf]
-  standard_name = magnitude_of_perturbation_of_vegetation_fraction
-  long_name = magnitude of perturbation of vegetation fraction
-  units = frac
-  dimensions = (5)
-  type = real
-  kind = kind_phys
+[lndp_var_list]
+  standard_name = variables_to_be_perturbed_for_landperts
+  long_name = variables to be perturbed for landperts
+  units = none
+  dimensions =  (number_of_land_surface_variables_perturbed) 
+  type = character
+  kind = len=3
 [ntrac]
   standard_name = number_of_tracers
   long_name = number of tracers
@@ -6162,6 +6134,13 @@
   standard_name = radar_reflectivity_10cm
   long_name = instantaneous refl_10cm
   units = dBZ
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+[cldfra]
+  standard_name = instantaneous_3d_cloud_fraction
+  long_name = instantaneous 3D cloud fraction for all MPs
+  units = frac
   dimensions = (horizontal_dimension,vertical_dimension)
   type = real
   kind = kind_phys
@@ -8914,6 +8893,13 @@
   long_name = tracer concentration diffused by PBL scheme
   units = kg kg-1
   dimensions = (horizontal_dimension,vertical_dimension,number_of_vertical_diffusion_tracers)
+  type = real
+  kind = kind_phys
+[lndp_vgf]
+  standard_name = magnitude_of_perturbation_of_vegetation_fraction
+  long_name = magnitude of perturbation of vegetation fraction
+  units = frac
+  dimensions = ()
   type = real
   kind = kind_phys
 [vegf1d]


### PR DESCRIPTION
update GFS_typedefs.[F90/meta] and ccpp/physics_namelists (to remove do_sfcperts) to work with latest ccpp-physics master