### PR TITLE
Update SCM suites to match FV3

### DIFF
--- a/ccpp/physics_namelists/input_GFS_v15p2.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_ACM.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_ACM.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_FA.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_FA.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_MYJ.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_MYJ.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP_LWjac.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_RRTMGP_LWjac.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_YSU.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_YSU.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_noahmp.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_noahmp.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v15p2_saYSU.nml
+++ b/ccpp/physics_namelists/input_GFS_v15p2_saYSU.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v16beta.nml
+++ b/ccpp/physics_namelists/input_GFS_v16beta.nml
@@ -2,6 +2,7 @@
        fhzero         = 6
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP.nml
+++ b/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP.nml
@@ -2,6 +2,7 @@
        fhzero         = 6
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP_LWjac.nml
+++ b/ccpp/physics_namelists/input_GFS_v16beta_RRTMGP_LWjac.nml
@@ -2,6 +2,7 @@
        fhzero         = 6
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24
        use_ufo        = .true.
        pre_rad        = .false.

--- a/ccpp/physics_namelists/input_GSD_v1.nml
+++ b/ccpp/physics_namelists/input_GSD_v1.nml
@@ -2,6 +2,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 0.
        nst_anl        = .true.
        use_ufo        = .true.
@@ -33,6 +34,7 @@
        lheatstrg      = .false.
        do_mynnedmf    = .true.
        do_mynnsfclay  = .false.
+       effr_in        = .true.
        random_clds    = .false.
        trans_trac     = .true.
        cnvcld         = .true.

--- a/ccpp/physics_namelists/input_csawmg.nml
+++ b/ccpp/physics_namelists/input_csawmg.nml
@@ -1,6 +1,7 @@
 &gfs_physics_nml
        fhzero         = 6.
        ldiag3d        = .true.
+       qdiag3d        = .true.
        fhcyc          = 24.
        nst_anl        = .true.
        use_ufo        = .true.
@@ -53,7 +54,6 @@
        oz_phys        = .false.
        oz_phys_2015   = .true.
        debug          = .false.
-
        ras            = .false.
        cscnv          = .true.
        do_shoc        = .false.
@@ -72,7 +72,7 @@
        mg_qcvar       = 1.0
        fprcp          = 2
        pdfflag        = 4
-       iccn           = 0
+       iccn           = 1
        mg_do_graupel  = .true.
        mg_do_hail     = .false.
        do_sb_physics  = .true.


### PR DESCRIPTION
This PR builds on https://github.com/NCAR/gmtb-scm/pull/213 (should be merged afterward).

It only updates SCM suites to function like FV3-based ones. No changes in SDFs were detected, but several changes in namelist settings were. They include:

- add qdiag3d = T for all suites (SCM-only change, since we always want to output moisture tendencies)
- add effr_in = T for the GSD_v1 suite
- set iccn = 1 in CSAWMG suite