### PR TITLE
Hotfix to fix ccpp_prebuild errors following RRTMGP changes

### DIFF
--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -200,8 +200,10 @@ SCHEME_FILES = [
     'ccpp/physics/physics/rrtmgp_lw_cloud_sampling.F90'     ,
     'ccpp/physics/physics/rrtmgp_sw_cloud_sampling.F90'     ,
     'ccpp/physics/physics/GFS_cloud_diagnostics.F90'        ,
+    'ccpp/physics/physics/GFS_rrtmgp_thompsonmp_pre.F90'    ,
     'ccpp/physics/physics/GFS_rrtmgp_gfdlmp_pre.F90'        ,
     'ccpp/physics/physics/GFS_rrtmgp_zhaocarr_pre.F90'      ,
+    'ccpp/physics/physics/GFS_rrtmgp_cloud_overlap_pre.F90' ,
     'ccpp/physics/physics/GFS_rrtmgp_sw_post.F90'
     ]
 
@@ -291,12 +293,6 @@ OPTIONAL_ARGUMENTS = {
             'rime_factor',
             ],
         },
-    'rrtmgp_lw_rte' : {
-         'rrtmgp_lw_rte_run' : [
-             'RRTMGP_jacobian_of_lw_flux_profile_upward',
-             'RRTMGP_jacobian_of_lw_flux_profile_downward',
-             ],
-         },          
     'rrtmgp_sw_rte' : {
          'rrtmgp_sw_rte_run' : [
              'components_of_surface_downward_shortwave_fluxes',
@@ -313,12 +309,6 @@ OPTIONAL_ARGUMENTS = {
              'tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_time_step',
              ],
          },
-    'GFS_suite_interstitial_2' : {
-         'GFS_suite_interstitial_2_run' : [
-             'RRTMGP_jacobian_of_lw_flux_profile_upward',
-             'RRTMGP_lw_flux_profile_upward_allsky',
-             ],
-         }, 
     #'subroutine_name_1' : 'all',
     #'subroutine_name_2' : 'none',
     #'subroutine_name_2' : [ 'var1', 'var3'],

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -407,7 +407,8 @@ module GFS_typedefs
                                                                  !< difference of dnfxc & upfxc from GFS_radtend_type%sfcfsw
     real (kind=kind_phys), pointer :: sfcdlw(:)      => null()   !< total sky sfc downward lw flux ( w/m**2 )
                                                                  !< GFS_radtend_type%sfclsw%dnfxc
-
+    real (kind=kind_phys), pointer :: sfculw(:)      => null()   !< total sky sfc upward lw flux ( w/m**2 ) 
+    real (kind=kind_phys), pointer :: sfculw_jac(:)  => null()   !< Jacobian of total sky sfc upward lw flux ( w/m**2/K ) 
 !--- incoming quantities
     real (kind=kind_phys), pointer :: dusfcin_cpl(:) => null()   !< aoi_fld%dusfcin(item,lan)
     real (kind=kind_phys), pointer :: dvsfcin_cpl(:) => null()   !< aoi_fld%dvsfcin(item,lan)
@@ -666,6 +667,7 @@ module GFS_typedefs
     logical              :: do_GPsw_Glw             !< If set to true use rrtmgp for SW calculation, rrtmg for LW.
     character(len=128)   :: active_gases_array(100) !< character array for each trace gas name
     logical              :: use_LW_jacobian         !< If true, use Jacobian of LW to update radiation tendency.
+    logical              :: doGP_lwscat             !< If true, include scattering in longwave cloud-optics, only compatible w/ GP cloud-optics
 !--- microphysical switch
     integer              :: ncld            !< choice of cloud scheme
     !--- new microphysical switch
@@ -1983,7 +1985,6 @@ module GFS_typedefs
     ! RRTMGP
     integer                             :: ipsdlw0                              !<
     integer                             :: ipsdsw0                              !<
-    real (kind=kind_phys), pointer      :: sktp1r(:)                 => null()  !<
     real (kind=kind_phys), pointer      :: p_lay(:,:)                => null()  !<
     real (kind=kind_phys), pointer      :: p_lev(:,:)                => null()  !<
     real (kind=kind_phys), pointer      :: t_lev(:,:)                => null()  !<
@@ -2035,10 +2036,10 @@ module GFS_typedefs
     type(ty_gas_optics_rrtmgp)          :: sw_gas_props                         !< RRTMGP DDT
     type(ty_cloud_optics)               :: lw_cloud_props                       !< RRTMGP DDT
     type(ty_cloud_optics)               :: sw_cloud_props                       !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_cloudsByBand        !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_clouds              !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_precipByBand        !< RRTMGP DDT
-    type(ty_optical_props_1scl)         :: lw_optical_props_precip              !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: lw_optical_props_cloudsByBand        !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: lw_optical_props_clouds              !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: lw_optical_props_precipByBand        !< RRTMGP DDT
+    type(ty_optical_props_2str)         :: lw_optical_props_precip              !< RRTMGP DDT
     type(ty_optical_props_1scl)         :: lw_optical_props_clrsky              !< RRTMGP DDT
     type(ty_optical_props_1scl)         :: lw_optical_props_aerosol             !< RRTMGP DDT
     type(ty_optical_props_2str)         :: sw_optical_props_cloudsByBand        !< RRTMGP DDT
@@ -2577,10 +2578,14 @@ module GFS_typedefs
     allocate (Coupling%sfcdsw (IM))
     allocate (Coupling%sfcnsw (IM))
     allocate (Coupling%sfcdlw (IM))
+    allocate (Coupling%sfculw (IM))
+    allocate (Coupling%sfculw_jac (IM))
 
     Coupling%sfcdsw = clear_val
     Coupling%sfcnsw = clear_val
     Coupling%sfcdlw = clear_val
+    Coupling%sfculw = clear_val
+    Coupling%sfculw_jac = clear_val
 
     if (Model%cplflx .or. Model%do_sppt .or. Model%cplchm .or. Model%ca_global) then
       allocate (Coupling%rain_cpl (IM))
@@ -2930,25 +2935,26 @@ module GFS_typedefs
     logical              :: lwhtr             = .true.       !< flag to output lw heating rate (Radtend%lwhc)
     logical              :: swhtr             = .true.       !< flag to output sw heating rate (Radtend%swhc)
     ! RRTMGP
-    logical              :: do_RRTMGP        = .false.       !< Use RRTMGP?
-    character(len=128)   :: active_gases    = ''             !< Character list of active gases used in RRTMGP
-    integer              :: nGases          = 0              !< Number of active gases
-    character(len=128)   :: rrtmgp_root     = ''             !< Directory of rte+rrtmgp source code
-    character(len=128)   :: lw_file_gas     = ''             !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
-    character(len=128)   :: lw_file_clouds  = ''             !< RRTMGP file containing coefficients used to compute clouds optical properties
-    integer              :: rrtmgp_nBandsLW = 16             !< Number of RRTMGP LW bands.
-    integer              :: rrtmgp_nGptsLW  = 256            !< Number of RRTMGP LW spectral points.
-    character(len=128)   :: sw_file_gas     = ''             !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
-    character(len=128)   :: sw_file_clouds  = ''             !< RRTMGP file containing coefficients used to compute clouds optical properties
-    integer              :: rrtmgp_nBandsSW = 14             !< Number of RRTMGP SW bands.
-    integer              :: rrtmgp_nGptsSW  = 224            !< Number of RRTMGP SW spectral points.
+    logical              :: do_RRTMGP           = .false.    !< Use RRTMGP?
+    character(len=128)   :: active_gases        = ''         !< Character list of active gases used in RRTMGP
+    integer              :: nGases              = 0          !< Number of active gases
+    character(len=128)   :: rrtmgp_root         = ''         !< Directory of rte+rrtmgp source code
+    character(len=128)   :: lw_file_gas         = ''         !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
+    character(len=128)   :: lw_file_clouds      = ''         !< RRTMGP file containing coefficients used to compute clouds optical properties
+    integer              :: rrtmgp_nBandsLW     = 16         !< Number of RRTMGP LW bands.
+    integer              :: rrtmgp_nGptsLW      = 256        !< Number of RRTMGP LW spectral points.
+    character(len=128)   :: sw_file_gas         = ''         !< RRTMGP K-distribution file, coefficients to compute optics for gaseous atmosphere
+    character(len=128)   :: sw_file_clouds      = ''         !< RRTMGP file containing coefficients used to compute clouds optical properties
+    integer              :: rrtmgp_nBandsSW     = 14         !< Number of RRTMGP SW bands.
+    integer              :: rrtmgp_nGptsSW      = 224        !< Number of RRTMGP SW spectral points.
     logical              :: doG_cldoptics       = .false.    !< Use legacy RRTMG cloud-optics?                                             
     logical              :: doGP_cldoptics_PADE = .false.    !< Use RRTMGP cloud-optics: PADE approximation?
     logical              :: doGP_cldoptics_LUT  = .false.    !< Use RRTMGP cloud-optics: LUTs?     
-    integer              :: rrtmgp_nrghice = 0               !< Number of ice-roughness categories
-    integer              :: rrtmgp_nGauss_ang=1              !< Number of angles used in Gaussian quadrature
-    logical              :: do_GPsw_Glw    = .false.     
-    logical              :: use_LW_jacobian = .false.        !< Use Jacobian of LW to update LW radiation tendencies. 
+    integer              :: rrtmgp_nrghice      = 0          !< Number of ice-roughness categories
+    integer              :: rrtmgp_nGauss_ang   = 1          !< Number of angles used in Gaussian quadrature
+    logical              :: do_GPsw_Glw         = .false.     
+    logical              :: use_LW_jacobian     = .false.    !< Use Jacobian of LW to update LW radiation tendencies. 
+    logical              :: doGP_lwscat         = .false.    !< If true, include scattering in longwave cloud-optics, only compatible w/ GP cloud-optics
 
 !--- Z-C microphysical parameters
     integer              :: ncld              =  1                 !< choice of cloud scheme
@@ -3323,7 +3329,7 @@ module GFS_typedefs
                                sw_file_gas, sw_file_clouds, rrtmgp_nBandsSW, rrtmgp_nGptsSW,&
                                doG_cldoptics, doGP_cldoptics_PADE, doGP_cldoptics_LUT,      &
                                rrtmgp_nrghice, rrtmgp_nGauss_ang, do_GPsw_Glw,              &
-                               use_LW_jacobian,                                             &
+                               use_LW_jacobian, doGP_lwscat,                                &
                           ! IN CCN forcing
                                iccn,                                                        &
                           !--- microphysical parameterizations
@@ -3683,10 +3689,16 @@ module GFS_typedefs
     Model%doGP_cldoptics_PADE = doGP_cldoptics_PADE
     Model%doGP_cldoptics_LUT  = doGP_cldoptics_LUT
     Model%use_LW_jacobian     = use_LW_jacobian
+    Model%doGP_lwscat         = doGP_lwscat
     ! RRTMGP incompatible with levr /= levs
     if (Model%do_RRTMGP .and. Model%levr /= Model%levs) then
       write(0,*) "Logic error, RRTMGP only works with levr = levs"
       stop
+    end if
+    ! RRTMGP LW scattering calculation not supported w/ RRTMG cloud-optics
+    if (Model%doGP_lwscat .and. Model%doG_cldoptics) then
+      write(0,*) "Logic error, RRTMGP Longwave cloud-scattering not supported with RRTMG cloud-optics."
+      stop       
     end if
 
     ! The CCPP versions of the RRTMG lw/sw schemes are configured
@@ -4784,6 +4796,7 @@ module GFS_typedefs
         print *, ' doGP_cldoptics_PADE: ', Model%doGP_cldoptics_PADE
         print *, ' doGP_cldoptics_LUT : ', Model%doGP_cldoptics_LUT
         print *, ' use_LW_jacobian    : ', Model%use_LW_jacobian
+        print *, ' doGP_lwscat        : ', Model%doGP_lwscat
       endif
       print *, ' '
       print *, 'microphysical switch'
@@ -6310,10 +6323,6 @@ module GFS_typedefs
     allocate (Interstitial%zt1d            (IM))
 
     ! RRTMGP
-    allocate (Interstitial%fluxlwDOWN_jac       (IM, Model%levs+1))
-    allocate (Interstitial%fluxlwUP_jac         (IM, Model%levs+1))
-    allocate (Interstitial%sktp1r               (IM))
-    allocate (Interstitial%fluxlwUP_allsky      (IM, Model%levs+1))
     if (Model%do_RRTMGP) then
        allocate (Interstitial%tracer               (IM, Model%levs,Model%ntrac))
        allocate (Interstitial%tv_lay               (IM, Model%levs))
@@ -6329,6 +6338,7 @@ module GFS_typedefs
        allocate (Interstitial%precip_overlap_param (IM, Model%levs))
        allocate (Interstitial%fluxlwDOWN_allsky    (IM, Model%levs+1))
        allocate (Interstitial%fluxlwUP_clrsky      (IM, Model%levs+1))
+       allocate (Interstitial%fluxlwUP_allsky      (IM, Model%levs+1))
        allocate (Interstitial%fluxlwDOWN_clrsky    (IM, Model%levs+1))
        allocate (Interstitial%fluxswUP_allsky      (IM, Model%levs+1))
        allocate (Interstitial%fluxswDOWN_allsky    (IM, Model%levs+1))
@@ -6748,6 +6758,7 @@ module GFS_typedefs
     end if
 
     if (Model%do_RRTMGP) then
+      Interstitial%fluxlwUP_allsky      = clear_val
       Interstitial%tracer               = clear_val
       Interstitial%tv_lay               = clear_val
       Interstitial%relhum               = clear_val

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -1634,6 +1634,20 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
+[sfculw]
+  standard_name = surface_upwelling_longwave_flux_on_radiation_time_step
+  long_name = total sky sfc upward lw flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+[sfculw_jac]
+  standard_name = RRTMGP_jacobian_of_lw_flux_upward_at_surface
+  long_name = RRTMGP Jacobian upward longwave flux at surface
+  units = W m-2 K-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
 [rain_cpl]
   standard_name = lwe_thickness_of_precipitation_amount_for_coupling
   long_name = total rain precipitation
@@ -2726,6 +2740,12 @@
   units = flag
   dimensions = ()
   type = logical 
+[doGP_lwscat] 
+  standard_name = flag_to_include_longwave_scattering_in_cloud_optics
+  long_name = logical flag to control the addition of LW scattering in RRTMGP 
+  units = flag
+  dimensions = ()
+  type = logical
 [rrtmgp_nrghice]
   standard_name = number_of_rrtmgp_ice_roughness
   long_name = number of ice-roughness categories in RRTMGP calculation (Model%rrtmgp_nrghice)
@@ -4574,12 +4594,6 @@
 [restart]
   standard_name = flag_for_restart
   long_name = flag for restart (warmstart) or coldstart
-  units = flag
-  dimensions = ()
-  type = logical
-[cycling]
-  standard_name = flag_for_cycling
-  long_name = flag for cycling or coldstart
   units = flag
   dimensions = ()
   type = logical
@@ -9905,6 +9919,24 @@
   dimensions = (horizontal_loop_extent,vertical_dimension)
   type = real
   kind = kind_phys
+[qs_lay]
+  standard_name = saturation_vapor_pressure
+  long_name = saturation vapor pressure
+  units = Pa
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  optional = F
+  active = (flag_for_rrtmgp_radiation_scheme)
+[q_lay]
+  standard_name = water_vapor_mixing_ratio
+  long_name = water vaport mixing ratio
+  units = kg/kg
+  dimensions = (horizontal_dimension,vertical_dimension)
+  type = real
+  kind = kind_phys
+  optional = F
+  active = (flag_for_rrtmgp_radiation_scheme)
 [p_lay]
   standard_name = air_pressure_at_layer_for_RRTMGP_in_hPa
   long_name = air pressure layer
@@ -10043,27 +10075,6 @@
   type = real
   kind = kind_phys
   active = (flag_for_rrtmgp_radiation_scheme)
-[sktp1r]
-  standard_name = surface_skin_temperature_at_previous_time_step
-  long_name = surface skin temperature at previous time step
-  units = K
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-[fluxlwUP_jac]
-  standard_name = RRTMGP_jacobian_of_lw_flux_profile_upward
-  long_name = RRTMGP Jacobian upward longwave flux profile
-  units = W m-2 K-1
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
-  type = real
-  kind = kind_phys
-[fluxlwDOWN_jac]
-  standard_name = RRTMGP_jacobian_of_lw_flux_profile_downward
-  long_name = RRTMGP Jacobian downward of longwave flux profile
-  units = W m-2 K-1
-  dimensions = (horizontal_loop_extent,vertical_dimension_plus_one)
-  type = real
-  kind = kind_phys
 [fluxswUP_allsky]
   standard_name = RRTMGP_sw_flux_profile_upward_allsky
   long_name = RRTMGP upward shortwave all-sky flux profile
@@ -10273,25 +10284,25 @@
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
-  type = ty_optical_props_1scl
+  type = ty_optical_props_2str
 [lw_optical_props_precip]
   standard_name = longwave_optical_properties_for_precipitation
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
-  type = ty_optical_props_1scl
+  type = ty_optical_props_2str
 [lw_optical_props_cloudsByBand]
   standard_name = longwave_optical_properties_for_cloudy_atmosphere_by_band
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
-  type = ty_optical_props_1scl
+  type = ty_optical_props_2str
 [lw_optical_props_precipByBand]
   standard_name = longwave_optical_properties_for_precipitation_by_band
   long_name = Fortran DDT containing RRTMGP optical properties
   units = DDT
   dimensions = ()
-  type = ty_optical_props_1scl
+  type = ty_optical_props_2str
 [lw_optical_props_aerosol]
   standard_name = longwave_optical_properties_for_aerosols
   long_name = Fortran DDT containing RRTMGP optical properties


### PR DESCRIPTION
 - add changes to ccpp_prebuild.py, GFS_typedefs.F90/meta following changes to RRTMGP
 - these changes follow https://github.com/NOAA-EMC/fv3atm/pull/208