### PR TITLE
DEPHY input format (plus forcing rework)

### DIFF
--- a/scm/etc/case_config/AMMA_REF.nml
+++ b/scm/etc/case_config/AMMA_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'AMMA_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/AMMA/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/ARMCU_E3SM.nml
+++ b/scm/etc/case_config/ARMCU_E3SM.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'ARMCU_E3SM',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/ARMCU/E3SM',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/ARMCU_MESONH.nml
+++ b/scm/etc/case_config/ARMCU_MESONH.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'ARMCU_MESONH',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/ARMCU/MESONH',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/ARMCU_REF.nml
+++ b/scm/etc/case_config/ARMCU_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'ARMCU_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/ARMCU/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/AYOTTE_00SC.nml
+++ b/scm/etc/case_config/AYOTTE_00SC.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'AYOTTE_00SC',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/AYOTTE/00SC',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/BOMEX_REF.nml
+++ b/scm/etc/case_config/BOMEX_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'BOMEX_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/BOMEX/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/DYNAMO_NSA3a.nml
+++ b/scm/etc/case_config/DYNAMO_NSA3a.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'DYNAMO_NSA3a',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/DYNAMO/NSA3a',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/DYNAMO_NSA3a_D1.nml
+++ b/scm/etc/case_config/DYNAMO_NSA3a_D1.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'DYNAMO_NSA3a_D1',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/DYNAMO/NSA3a_D1',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/GABLS1_REF.nml
+++ b/scm/etc/case_config/GABLS1_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'GABLS1_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/GABLS1/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/IHOP_REF.nml
+++ b/scm/etc/case_config/IHOP_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'IHOP_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/IHOP/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/MPACE_REF.nml
+++ b/scm/etc/case_config/MPACE_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'MPACE_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/MPACE/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/RICO_MESONH.nml
+++ b/scm/etc/case_config/RICO_MESONH.nml
@@ -1,7 +1,7 @@
 $case_config
 model_name = 'FV3',
 n_columns = 1,
-case_name = 'armcu',
+case_name = 'RICO_MESONH',
 input_type = 1
 dt = 600.0,
 time_scheme = 1,
@@ -9,12 +9,12 @@ n_itt_out = 1,
 n_itt_diag = 1,
 n_levels = 64,
 output_file = 'output',
-case_data_dir = '../data/processed_case_input',
+case_data_dir = '../data/DEPHY-SCM/RICO/MESONH',
 vert_coord_data_dir = '../data/vert_coord_data',
 lsm_ics = .false.,
 do_spinup = .false.,
 spinup_timesteps = 0,
 reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
 column_area = 1.45E8,
-sfc_flux_spec = .true.
 $end

--- a/scm/etc/case_config/SANDU_FAST.nml
+++ b/scm/etc/case_config/SANDU_FAST.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'SANDU_FAST',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/SANDU/FAST',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/SANDU_REF.nml
+++ b/scm/etc/case_config/SANDU_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'SANDU_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/SANDU/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/SANDU_SLOW.nml
+++ b/scm/etc/case_config/SANDU_SLOW.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'SANDU_SLOW',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/SANDU/SLOW',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/SCMS_REF.nml
+++ b/scm/etc/case_config/SCMS_REF.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'SCMS_REF',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/DEPHY-SCM/SCMS/REF',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+reference_profile_dir = '../data/processed_case_input'
+column_area = 1.45E8,
+$end

--- a/scm/etc/case_config/armcu.nml
+++ b/scm/etc/case_config/armcu.nml
@@ -1,0 +1,20 @@
+$case_config
+model_name = 'FV3',
+n_columns = 1,
+case_name = 'armcu',
+input_type = 1
+dt = 600.0,
+time_scheme = 1,
+n_itt_out = 1,
+n_itt_diag = 1,
+n_levels = 64,
+output_file = 'output',
+case_data_dir = '../data/processed_case_input',
+vert_coord_data_dir = '../data/vert_coord_data',
+lsm_ics = .false.,
+do_spinup = .false.,
+spinup_timesteps = 0,
+reference_profile_choice = 2,
+column_area = 1.45E8,
+sfc_flux_spec = .true.
+$end

--- a/scm/etc/scripts/configspec.ini
+++ b/scm/etc/scripts/configspec.ini
@@ -9,8 +9,8 @@ time_series_resample = boolean()
 [time_slices]
 
   [[__many__]]
-    start = int_list(min=4, max=4)
-    end = int_list(min=4, max=4)
+    start = int_list(min=4, max=5)
+    end = int_list(min=4, max=5)
 
 [plots]
   [[profiles_mean]]

--- a/scm/etc/scripts/gmtb_scm_analysis.py
+++ b/scm/etc/scripts/gmtb_scm_analysis.py
@@ -519,11 +519,11 @@ for i in range(len(gmtb_scm_datasets)):
     rad_eff_rad_qs.append(nc_fid.variables['rad_eff_rad_qs'][:])
     inst_time_group.append('rad_eff_rad_qs')
     
-    sw_rad_heating_rate.append(nc_fid.variables['sw_rad_heating_rate'][:])
-    swrad_time_group.append('sw_rad_heating_rate')
+    #sw_rad_heating_rate.append(nc_fid.variables['sw_rad_heating_rate'][:])
+    #swrad_time_group.append('sw_rad_heating_rate')
     
-    lw_rad_heating_rate.append(nc_fid.variables['lw_rad_heating_rate'][:])
-    lwrad_time_group.append('lw_rad_heating_rate')
+    #lw_rad_heating_rate.append(nc_fid.variables['lw_rad_heating_rate'][:])
+    #lwrad_time_group.append('lw_rad_heating_rate')
     
     pwat.append(nc_fid.variables['pwat'][:]) #convert to cm
     inst_time_group.append('pwat')
@@ -795,17 +795,25 @@ for time_slice in time_slices:
     end_date_index_diag = valid_diag_indices[0][-1]
     
     valid_swrad_indices = np.where((date_swrad[0] >= start_date) & (date_swrad[0] <= end_date))
-    start_date_index_swrad = valid_swrad_indices[0][0]
-    end_date_index_swrad = valid_swrad_indices[0][-1]
+    if (len(valid_swrad_indices[0]) > 0):
+        start_date_index_swrad = valid_swrad_indices[0][0]
+        end_date_index_swrad = valid_swrad_indices[0][-1]
+        time_slice_indices_swrad.append([start_date_index_swrad, end_date_index_swrad])
+    else:
+        start_date_index_swrad = 0
+        end_date_index_swrad = 0
     
     valid_lwrad_indices = np.where((date_lwrad[0] >= start_date) & (date_lwrad[0] <= end_date))
-    start_date_index_lwrad = valid_lwrad_indices[0][0]
-    end_date_index_lwrad = valid_lwrad_indices[0][-1]    
+    if (len(valid_lwrad_indices[0]) > 0):
+        start_date_index_lwrad = valid_lwrad_indices[0][0]
+        end_date_index_lwrad = valid_lwrad_indices[0][-1]
+        time_slice_indices_lwrad.append([start_date_index_lwrad, end_date_index_lwrad])
+    else:
+        start_date_index_lwrad = 0
+        end_date_index_lwrad = 0
     
     time_slice_indices_inst.append([start_date_index_inst, end_date_index_inst])
     time_slice_indices_diag.append([start_date_index_diag, end_date_index_diag])
-    time_slice_indices_swrad.append([start_date_index_swrad, end_date_index_swrad])
-    time_slice_indices_lwrad.append([start_date_index_lwrad, end_date_index_lwrad])
 
 #fill the obs_dict by calling the appropriate observation file read routine
 if(obs_compare and obs_file):

--- a/scm/etc/scripts/gmtb_scm_analysis.py
+++ b/scm/etc/scripts/gmtb_scm_analysis.py
@@ -93,6 +93,14 @@ if(len(gmtb_scm_datasets) > 1):
 
 num_plots_completed = 0
 
+#make sure that each time slice is a list of length 5 -- year, month, day, hour, min (append zero for minute if necessary)
+for time_slice in time_slices:
+    if (len(time_slices[time_slice]['start']) < 5):
+        for i in range(5 - len(time_slices[time_slice]['start'])):
+            time_slices[time_slice]['start'].append(0)
+    if (len(time_slices[time_slice]['end']) < 5):
+        for i in range(5 - len(time_slices[time_slice]['end'])):
+            time_slices[time_slice]['end'].append(0)
 
 #perform any special checks on the config file data
 if len(gmtb_scm_datasets) != len(gmtb_scm_datasets_labels):
@@ -123,6 +131,7 @@ year = []
 month = []
 day = []
 hour = []
+minute = []
 time_inst = []
 time_diag = []
 time_swrad = []
@@ -312,6 +321,7 @@ for i in range(len(gmtb_scm_datasets)):
     month.append(nc_fid.variables['init_month'][:])
     day.append(nc_fid.variables['init_day'][:])
     hour.append(nc_fid.variables['init_hour'][:])
+    minute.append(nc_fid.variables['init_minute'][:])
 
     time_inst.append(nc_fid.variables['time_inst'][:])
     time_diag.append(nc_fid.variables['time_diag'][:])
@@ -519,11 +529,11 @@ for i in range(len(gmtb_scm_datasets)):
     rad_eff_rad_qs.append(nc_fid.variables['rad_eff_rad_qs'][:])
     inst_time_group.append('rad_eff_rad_qs')
     
-    #sw_rad_heating_rate.append(nc_fid.variables['sw_rad_heating_rate'][:])
-    #swrad_time_group.append('sw_rad_heating_rate')
+    sw_rad_heating_rate.append(nc_fid.variables['sw_rad_heating_rate'][:])
+    swrad_time_group.append('sw_rad_heating_rate')
     
-    #lw_rad_heating_rate.append(nc_fid.variables['lw_rad_heating_rate'][:])
-    #lwrad_time_group.append('lw_rad_heating_rate')
+    lw_rad_heating_rate.append(nc_fid.variables['lw_rad_heating_rate'][:])
+    lwrad_time_group.append('lw_rad_heating_rate')
     
     pwat.append(nc_fid.variables['pwat'][:]) #convert to cm
     inst_time_group.append('pwat')
@@ -737,7 +747,7 @@ for i in range(len(gmtb_scm_datasets)):
     # lw_dn_sfc_tot.append(nc_fid.variables['lw_dn_sfc_tot'][:])
     # lw_dn_sfc_clr.append(nc_fid.variables['lw_dn_sfc_clr'][:])
 
-    initial_date = datetime.datetime(year[i], month[i], day[i], hour[i], 0, 0, 0)
+    initial_date = datetime.datetime(year[i], month[i], day[i], hour[i], minute[i], 0, 0)
     
     #convert times to datetime objects starting from initial date
     date_inst.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_inst[-1]]))
@@ -783,8 +793,8 @@ time_h_lwrad = [x/3600.0 for x in time_lwrad]
 #find the indices corresponding to the start and end times of the time slices defined in the config file
 for time_slice in time_slices:
     time_slice_labels.append(time_slice)
-    start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3])
-    end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3])
+    start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3],time_slices[time_slice]['start'][4])
+    end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3],time_slices[time_slice]['end'][4])
     
     valid_inst_indices = np.where((date_inst[0] >= start_date) & (date_inst[0] <= end_date))
     start_date_index_inst = valid_inst_indices[0][0]
@@ -795,22 +805,26 @@ for time_slice in time_slices:
     end_date_index_diag = valid_diag_indices[0][-1]
     
     valid_swrad_indices = np.where((date_swrad[0] >= start_date) & (date_swrad[0] <= end_date))
-    if (len(valid_swrad_indices[0]) > 0):
+    
+    if (len(valid_swrad_indices[0]) > 1):
         start_date_index_swrad = valid_swrad_indices[0][0]
         end_date_index_swrad = valid_swrad_indices[0][-1]
         time_slice_indices_swrad.append([start_date_index_swrad, end_date_index_swrad])
     else:
-        start_date_index_swrad = 0
-        end_date_index_swrad = 0
+        start_date_index_swrad = valid_swrad_indices[0][0]
+        end_date_index_swrad = valid_swrad_indices[0][-1]
+        time_slice_indices_swrad.append([start_date_index_swrad, end_date_index_swrad+1])
+        
     
     valid_lwrad_indices = np.where((date_lwrad[0] >= start_date) & (date_lwrad[0] <= end_date))
-    if (len(valid_lwrad_indices[0]) > 0):
+    if (len(valid_lwrad_indices[0]) > 1):
         start_date_index_lwrad = valid_lwrad_indices[0][0]
         end_date_index_lwrad = valid_lwrad_indices[0][-1]
         time_slice_indices_lwrad.append([start_date_index_lwrad, end_date_index_lwrad])
     else:
-        start_date_index_lwrad = 0
-        end_date_index_lwrad = 0
+        start_date_index_lwrad = valid_lwrad_indices[0][0]
+        end_date_index_lwrad = valid_lwrad_indices[0][-1]
+        time_slice_indices_lwrad.append([start_date_index_lwrad, end_date_index_lwrad+1])
     
     time_slice_indices_inst.append([start_date_index_inst, end_date_index_inst])
     time_slice_indices_diag.append([start_date_index_diag, end_date_index_diag])

--- a/scm/etc/scripts/gmtb_scm_plotting_routines.py
+++ b/scm/etc/scripts/gmtb_scm_plotting_routines.py
@@ -412,6 +412,10 @@ def contour_plot_firl(x_dim, y_dim, values, min_val, max_val, title, x_label, y_
     if np.count_nonzero(values) == 0:
         print('The plot for {} will not be created due to all zero values'.format(title))
         return
+        
+    if np.amax(values) == np.amin(values):
+        print('The plot for {} will not be created due to all values being equal'.format(title))
+        return
     
     if(min_val != -999 and max_val != -999):
         min_val = conversion_factor*min_val

--- a/scm/etc/scripts/gmtb_scm_read_obs.py
+++ b/scm/etc/scripts/gmtb_scm_read_obs.py
@@ -24,8 +24,8 @@ def read_twpice_obs(obs_file, time_slices, date):
   obs_date = np.array(obs_date)
 
   for time_slice in time_slices:
-      start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3])
-      end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3])
+      start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3], time_slices[time_slice]['start'][4])
+      end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3], time_slices[time_slice]['end'][4])
       start_date_index = np.where(obs_date == start_date)[0][0]
       end_date_index = np.where(obs_date == end_date)[0][0]
       obs_time_slice_indices.append([start_date_index, end_date_index])
@@ -110,8 +110,8 @@ def read_arm_sgp_summer_1997_obs(obs_file, time_slices, date):
   obs_date = np.array(obs_date)
 
   for time_slice in time_slices:
-    start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3])
-    end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3])
+    start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3], time_slices[time_slice]['start'][4])
+    end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3], time_slices[time_slice]['end'][4])
     start_date_index = np.where(obs_date == start_date)[0][0]
     end_date_index = np.where(obs_date == end_date)[0][0]
     obs_time_slice_indices.append([start_date_index, end_date_index])
@@ -205,8 +205,8 @@ def read_LASSO_obs(obs_file, time_slices, date):
     obs_date = np.array(obs_date)
 
     for time_slice in time_slices:
-      start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3])
-      end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3])
+      start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3], time_slices[time_slice]['start'][4])
+      end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3], time_slices[time_slice]['end'][4])
       start_date_index = np.where(obs_date == start_date)[0][0]
       end_date_index = np.where(obs_date == end_date)[0][0]
       obs_time_slice_indices.append([start_date_index, end_date_index])
@@ -271,8 +271,8 @@ def read_gabls3_obs(obs_file, time_slices, date):
     obs_date = np.array(obs_date)
     
     for time_slice in time_slices:
-      start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3])
-      end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3])
+      start_date = datetime.datetime(time_slices[time_slice]['start'][0], time_slices[time_slice]['start'][1],time_slices[time_slice]['start'][2], time_slices[time_slice]['start'][3], time_slices[time_slice]['start'][4])
+      end_date = datetime.datetime(time_slices[time_slice]['end'][0], time_slices[time_slice]['end'][1],time_slices[time_slice]['end'][2], time_slices[time_slice]['end'][3], time_slices[time_slice]['end'][4])
       start_date_index = np.where(obs_date == start_date)[0][0]
       try:
           end_date_index = np.where(obs_date == end_date)[0][0]

--- a/scm/etc/scripts/plot_configs/all_vars_armcu.ini
+++ b/scm/etc/scripts/plot_configs/all_vars_armcu.ini
@@ -1,0 +1,166 @@
+gmtb_scm_datasets = output_ARMCU_REF_SCM_GFS_v15p2/output.nc, 
+gmtb_scm_datasets_labels = GFSv15p2, 
+plot_dir = plots_armcu/
+obs_file = ''
+obs_compare = False
+plot_ind_datasets = True
+time_series_resample = False
+
+[time_slices]
+  [[total]]
+    start = 1997, 6, 21, 11, 30
+    end = 1997, 6, 22, 2, 0
+
+[time_snapshots]
+
+[plots]
+  [[profiles_mean]]
+    vars = qv, T, u, v, qc, ql, qi, w_ls, u_g, v_g, dT_dt_rad_forc, rad_cloud_fraction
+    vars_labels = 'specific humidity ($g$ $kg^{-1}$)', 'T (K)', 'u ($m$ $s^{-1}$)', 'v ($m$ $s^{-1}$)', 'total cloud water (res + sgs) ($g$ $kg^{-1}$)', 'res. liquid cloud water ($g$ $kg^{-1}$)', 'res. ice cloud water ($g$ $kg^{-1}$)', 'forcing vertical velocity ($m$ $s^{-1}$)', 'forcing geo. u ($m$ $s^{-1}$)', 'forcing geo. v ($m$ $s^{-1}$)','radiative forcing ($K$ $s^{-1}$)','cloud fraction'
+    vert_axis = pres_l
+    vert_axis_label = 'p (Pa)'
+    y_inverted = True
+    y_log = False
+    y_min_option = min              #min, max, val (if val, add y_min = float value)
+    y_max_option = max              #min, max, val (if val, add y_max = float value)
+    conversion_factor = 1000.0, 1.0, 1.0, 1.0, 1000.0, 1000.0, 1000.0, 1.0, 1.0, 1.0, 1.0, 1.0
+
+  [[profiles_mean_multi]]
+    [[[thil_adv]]]
+      vars = h_advec_thil, v_advec_thil
+      vars_labels = 'horizontal adv. $\theta_{il}$','vertical adv. $\theta_{il}$'
+      x_label = '$K$ $day^{-1}$'
+      conversion_factor = 86400.0
+    [[[qt_adv]]]
+      vars = h_advec_qt, v_advec_qt
+      vars_labels = 'horizontal adv. $q_t$','vertical adv. $q_t$'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[conv_mass_flux]]]
+      vars = upd_mf, dwn_mf, det_mf
+      vars_labels = 'updraft mass flux','downdraft mass flux','detrainment mass flux'
+      x_label = '$kg$ $m^{-2}$ $s^{-1}$'
+    [[[T_tendencies]]]
+      vars = dT_dt_pbl, dT_dt_deepconv, dT_dt_shalconv, dT_dt_micro, dT_dt_lwrad, dT_dt_swrad, dT_dt_ogwd, dT_dt_rayleigh, dT_dt_cgwd
+      vars_labels = 'PBL', 'Deep Con', 'Shal Con', 'MP', 'LW', 'SW', 'OGWD', 'Rayleigh', 'CGWD'
+      x_label = '$K$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[T_force_phys]]]
+      vars = T_force_tend, dT_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$K$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[q_tendencies]]]
+      vars = qv_force_tend, dq_dt_pbl, dq_dt_deepconv, dq_dt_shalconv, dq_dt_micro
+      vars_labels = 'force', 'PBL', 'Deep Con', 'Shal Con', 'MP'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[q_force_phys]]]
+      vars = qv_force_tend, dq_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[oz_tendencies]]]
+      vars = doz_dt_pbl, doz_dt_prodloss, doz_dt_oz, doz_dt_T, doz_dt_ovhd
+      vars_labels = 'PBL', 'prod/loss', 'oz', 'T', 'ovhd'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[u_tendencies]]]
+      vars = du_dt_pbl, du_dt_ogwd, du_dt_deepconv, du_dt_shalconv, du_dt_cgwd, du_dt_rayleigh
+      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD', 'Rayleigh'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[u_force_phys]]]
+      vars = u_force_tend, du_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[v_tendencies]]]
+      vars = dv_dt_pbl, dv_dt_ogwd, dv_dt_deepconv, dv_dt_shalconv, dv_dt_cgwd, dv_dt_rayleigh
+      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD', 'Rayleigh'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[v_force_phys]]]
+      vars = v_force_tend, dv_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[water_path]]]
+      vars = rad_cloud_lwp, rad_cloud_iwp, rad_cloud_rwp, rad_cloud_swp
+      vars_labels = 'cloud liquid water path','cloud ice water path','rain water path','snow water path'
+      x_label = '$g$ $m^{-2}$'
+    [[[effective_radius]]]
+      vars = rad_eff_rad_ql, rad_eff_rad_qi, rad_eff_rad_qr, rad_eff_rad_qs
+      vars_labels = 'cloud liquid effective radius','cloud ice effective radius','rain effective radius','snow effective radius'
+      x_label = '$\mu m$'
+    [[[rad_heating_rate]]]
+      vars = sw_rad_heating_rate, lw_rad_heating_rate
+      vars_labels = 'SW heating rate','LW heating rate'
+      x_label = '$K day^{-1}$'
+      conversion_factor = 8.64E4
+    
+      
+      
+  [[profiles_instant]]
+
+  [[time_series]]
+    vars = pres_s, lhf, shf , T_s , tprcp_inst, tprcp_rate_inst, tau_u, tau_v, pwat, sfc_net_sw, tprcp_rate_accum, sfc_up_lw_land, sfc_dwn_lw, sfc_rad_net_land, gflux, t2m, q2m, ustar, u10m, v10m, hpbl, tsfc, sfc_dwn_sw, sfc_up_sw
+    vars_labels = 'surface pressure','sfc latent heat flux ($W$ $m^{-2}$)','sfc sensible heat flux ($W$ $m^{-2}$)','surface forcing temperature (K)','instantaneous LWE total precipitation ($m$)','instantaneous LWE total precipitation rate ($mm$ $h^{-1}$)','sfc u stress ($Pa$)','sfc v stress ($Pa$)','precipitable water ($cm$)', 'sfc net SW (total) ($W$ $m^{-2}$)', 'accumulated total precipitation rate ($mm$ $h^{-1}$)', 'sfc upwelling LW ($W$ $m^{-2}$)', 'sfc downwelling LW ($W$ $m^{-2}$)','sfc net radiation ($W$ $m^{-2}$)','ground heat flux ($W$ $m^{-2}$)','2-m temperature ($K$)','2-m specific humidity ($g$ $kg^{-1}$)','friction velocity ($m$ $s^{-1}$)', '10-m zonal wind ($m$ $s^{-1}$)','10-m meridional wind ($m$ $s^{-1}$)','PBL height ($m)','sfc skin temperature ($K$)','sfc downwelling SW ($W$ $m^{-2}$)','sfc upwelling SW ($W$ $m^{-2}$)'
+    conversion_factor = 1.0, 1.0, 1.0, 1.0, 1.0, 3.6E6, 1.0, 1.0, 0.1, 1.0, 3.6E6, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0E3, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0
+    
+  [[time_series_multi]]
+    [[[soil_T]]]
+      vars = soil_T, soil_T, soil_T, soil_T
+      levels = 1, 2, 3, 4
+      vars_labels = '10 cm','40 cm','100 cm','200 cm'
+      y_label = '$K$'
+    [[[soil_moisture]]]
+      vars = soil_moisture, soil_moisture, soil_moisture, soil_moisture
+      levels = 1, 2, 3, 4
+      vars_labels = '10 cm','40 cm','100 cm','200 cm'
+      y_label = '$m^3$ $m^{-3}$'
+    [[[soil_moisture_unfrozen]]]
+      vars = soil_moisture_unfrozen, soil_moisture_unfrozen, soil_moisture_unfrozen, soil_moisture_unfrozen
+      levels = 1, 2, 3, 4
+      vars_labels = '10 cm','40 cm','100 cm','200 cm'
+      y_label = '$m^3$ $m^{-3}$'
+    [[[surface_prcp_inst]]]
+      vars = tprcp_inst, mp_prcp_inst, dcnv_prcp_inst, scnv_prcp_inst
+      vars_labels = 'total','microphysics','deep conv.','shal conv.'
+      y_label = '$m$'
+    [[[surface_prcp_accum]]]
+      vars = tprcp_accum, ice_accum, snow_accum, graupel_accum, conv_prcp_accum
+      vars_labels = 'total','ice','snow','graupel','conv'
+      y_label = '$m$'
+    [[[surface_prcp_rate_accum]]]
+      vars = tprcp_rate_accum, ice_rate_accum, snow_rate_accum, graupel_rate_accum, conv_prcp_rate_accum
+      vars_labels = 'total','ice','snow','graupel','conv'
+      y_label = '$mm$ $h^{-1}$'
+      conversion_factor = 3.6E6
+    [[[surface_sw_down]]]
+      vars = sfc_dwn_sw, sfc_dwn_sw_dir_nir, sfc_dwn_sw_dif_nir, sfc_dwn_sw_dir_vis, sfc_dwn_sw_dif_vis
+      vars_labels = 'sfc downwelling SW (total)', 'sfc downwelling SW (direct near-infrared)','sfc downwelling SW (diffuse near-infrared)','sfc downwelling SW (direct uv+vis)','sfc downwelling SW (diffuse uv+vis)'
+      y_label = '($W$ $m^{-2}$)'
+    [[[surface_sw_up]]]
+      vars = sfc_up_sw, sfc_up_sw_dir_nir, sfc_up_sw_dif_nir, sfc_up_sw_dir_vis, sfc_up_sw_dif_vis
+      vars_labels = 'sfc upwelling SW (total)','sfc upwelling SW (direct near-infrared)','sfc upwelling SW (diffuse near-infrared)', 'sfc upwelling SW (direct uv+vis)','sfc upwelling SW (diffuse uv+vis)'
+      y_label = '($W$ $m^{-2}$)'
+    [[[surface_lw]]]
+      vars = sfc_dwn_lw, sfc_up_lw_land, sfc_up_lw_ocean, sfc_up_lw_ice
+      vars_labels = 'sfc downwelling LW (total)','sfc upwelling LW (land)','sfc upwelling LW (ocean)','sfc upwelling LW (ice)'
+      y_label = '($W$ $m^{-2}$)'
+  
+  [[contours]]
+    vars = qv, T, u, v, qc, ql, qi
+    vars_labels = 'specific humidity ($g$ $kg^{-1}$)', 'T (K)', 'u ($m$ $s^{-1}$)', 'v ($m$ $s^{-1}$)', 'total cloud water (res + sgs) ($g$ $kg^{-1}$)', 'res. liquid cloud water ($g$ $kg^{-1}$)', 'res. ice cloud water ($g$ $kg^{-1}$)'
+    vert_axis = pres_l
+    vert_axis_label = 'p (Pa)'
+    y_inverted = True
+    y_log = False
+    y_min_option = val             #min, max, val (if val, add y_min = float value)
+    y_min = 10000.0
+    y_max_option = val              #min, max, val (if val, add y_max = float value)
+    y_max = 100000.0
+    x_ticks_num = 10
+    y_ticks_num = 10
+    conversion_factor = 1000.0, 1.0, 1.0, 1.0, 1000.0, 1000.0, 1000.0

--- a/scm/etc/scripts/plot_configs/all_vars_dynamo.ini
+++ b/scm/etc/scripts/plot_configs/all_vars_dynamo.ini
@@ -1,0 +1,160 @@
+gmtb_scm_datasets = output_DYNAMO_NSA3a_SCM_GFS_v15p2/output.nc, 
+gmtb_scm_datasets_labels = GFSv15p2, 
+plot_dir = plots_dynamo/
+obs_file = ''
+obs_compare = False
+plot_ind_datasets = True
+time_series_resample = False
+
+[time_slices]
+  [[total]]
+    start = 2011, 12, 30, 0
+    end = 2011, 12, 31, 0
+
+[time_snapshots]
+
+[plots]
+  [[profiles_mean]]
+    vars = qv, T, u, v, qc, ql, qi, w_ls, u_g, v_g, dT_dt_rad_forc, rad_cloud_fraction
+    vars_labels = 'specific humidity ($g$ $kg^{-1}$)', 'T (K)', 'u ($m$ $s^{-1}$)', 'v ($m$ $s^{-1}$)', 'total cloud water (res + sgs) ($g$ $kg^{-1}$)', 'res. liquid cloud water ($g$ $kg^{-1}$)', 'res. ice cloud water ($g$ $kg^{-1}$)', 'forcing vertical velocity ($m$ $s^{-1}$)', 'forcing geo. u ($m$ $s^{-1}$)', 'forcing geo. v ($m$ $s^{-1}$)','radiative forcing ($K$ $s^{-1}$)','cloud fraction'
+    vert_axis = pres_l
+    vert_axis_label = 'p (Pa)'
+    y_inverted = True
+    y_log = False
+    y_min_option = min              #min, max, val (if val, add y_min = float value)
+    y_max_option = max              #min, max, val (if val, add y_max = float value)
+    conversion_factor = 1000.0, 1.0, 1.0, 1.0, 1000.0, 1000.0, 1000.0, 1.0, 1.0, 1.0, 1.0, 1.0
+
+  [[profiles_mean_multi]]
+    [[[thil_adv]]]
+      vars = h_advec_thil, v_advec_thil
+      vars_labels = 'horizontal adv. $\theta_{il}$','vertical adv. $\theta_{il}$'
+      x_label = '$K$ $day^{-1}$'
+      conversion_factor = 86400.0
+    [[[qt_adv]]]
+      vars = h_advec_qt, v_advec_qt
+      vars_labels = 'horizontal adv. $q_t$','vertical adv. $q_t$'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[conv_mass_flux]]]
+      vars = upd_mf, dwn_mf, det_mf
+      vars_labels = 'updraft mass flux','downdraft mass flux','detrainment mass flux'
+      x_label = '$kg$ $m^{-2}$ $s^{-1}$'
+    [[[T_tendencies]]]
+      vars = dT_dt_pbl, dT_dt_deepconv, dT_dt_shalconv, dT_dt_micro, dT_dt_lwrad, dT_dt_swrad, dT_dt_ogwd, dT_dt_rayleigh, dT_dt_cgwd
+      vars_labels = 'PBL', 'Deep Con', 'Shal Con', 'MP', 'LW', 'SW', 'OGWD', 'Rayleigh', 'CGWD'
+      x_label = '$K$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[T_force_phys]]]
+      vars = T_force_tend, dT_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$K$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[q_tendencies]]]
+      vars = qv_force_tend, dq_dt_pbl, dq_dt_deepconv, dq_dt_shalconv, dq_dt_micro
+      vars_labels = 'force', 'PBL', 'Deep Con', 'Shal Con', 'MP'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[q_force_phys]]]
+      vars = qv_force_tend, dq_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[oz_tendencies]]]
+      vars = doz_dt_pbl, doz_dt_prodloss, doz_dt_oz, doz_dt_T, doz_dt_ovhd
+      vars_labels = 'PBL', 'prod/loss', 'oz', 'T', 'ovhd'
+      x_label = '$g$ $kg^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E7
+    [[[u_tendencies]]]
+      vars = du_dt_pbl, du_dt_ogwd, du_dt_deepconv, du_dt_shalconv, du_dt_cgwd, du_dt_rayleigh
+      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD', 'Rayleigh'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[u_force_phys]]]
+      vars = u_force_tend, du_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[v_tendencies]]]
+      vars = dv_dt_pbl, dv_dt_ogwd, dv_dt_deepconv, dv_dt_shalconv, dv_dt_cgwd, dv_dt_rayleigh
+      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD', 'Rayleigh'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[v_force_phys]]]
+      vars = v_force_tend, dv_dt_phys
+      vars_labels = 'forcing', 'physics'
+      x_label = '$m$ $s^{-1}$ $day^{-1}$'
+      conversion_factor = 8.64E4
+    [[[water_path]]]
+      vars = rad_cloud_lwp, rad_cloud_iwp, rad_cloud_rwp, rad_cloud_swp
+      vars_labels = 'cloud liquid water path','cloud ice water path','rain water path','snow water path'
+      x_label = '$g$ $m^{-2}$'
+    [[[effective_radius]]]
+      vars = rad_eff_rad_ql, rad_eff_rad_qi, rad_eff_rad_qr, rad_eff_rad_qs
+      vars_labels = 'cloud liquid effective radius','cloud ice effective radius','rain effective radius','snow effective radius'
+      x_label = '$\mu m$'
+      
+      
+  [[profiles_instant]]
+
+  [[time_series]]
+    vars = pres_s, lhf, shf , T_s , tprcp_inst, tprcp_rate_inst, tau_u, tau_v, pwat, sfc_net_sw, tprcp_rate_accum, sfc_up_lw_land, sfc_dwn_lw, sfc_rad_net_land, gflux, t2m, q2m, ustar, u10m, v10m, hpbl, tsfc, sfc_dwn_sw, sfc_up_sw
+    vars_labels = 'surface pressure','sfc latent heat flux ($W$ $m^{-2}$)','sfc sensible heat flux ($W$ $m^{-2}$)','surface forcing temperature (K)','instantaneous LWE total precipitation ($m$)','instantaneous LWE total precipitation rate ($mm$ $h^{-1}$)','sfc u stress ($Pa$)','sfc v stress ($Pa$)','precipitable water ($cm$)', 'sfc net SW (total) ($W$ $m^{-2}$)', 'accumulated total precipitation rate ($mm$ $h^{-1}$)', 'sfc upwelling LW ($W$ $m^{-2}$)', 'sfc downwelling LW ($W$ $m^{-2}$)','sfc net radiation ($W$ $m^{-2}$)','ground heat flux ($W$ $m^{-2}$)','2-m temperature ($K$)','2-m specific humidity ($g$ $kg^{-1}$)','friction velocity ($m$ $s^{-1}$)', '10-m zonal wind ($m$ $s^{-1}$)','10-m meridional wind ($m$ $s^{-1}$)','PBL height ($m)','sfc skin temperature ($K$)','sfc downwelling SW ($W$ $m^{-2}$)','sfc upwelling SW ($W$ $m^{-2}$)'
+    conversion_factor = 1.0, 1.0, 1.0, 1.0, 1.0, 3.6E6, 1.0, 1.0, 0.1, 1.0, 3.6E6, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0E3, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0
+    
+  [[time_series_multi]]
+    [[[soil_T]]]
+      vars = soil_T, soil_T, soil_T, soil_T
+      levels = 1, 2, 3, 4
+      vars_labels = '10 cm','40 cm','100 cm','200 cm'
+      y_label = '$K$'
+    [[[soil_moisture]]]
+      vars = soil_moisture, soil_moisture, soil_moisture, soil_moisture
+      levels = 1, 2, 3, 4
+      vars_labels = '10 cm','40 cm','100 cm','200 cm'
+      y_label = '$m^3$ $m^{-3}$'
+    [[[soil_moisture_unfrozen]]]
+      vars = soil_moisture_unfrozen, soil_moisture_unfrozen, soil_moisture_unfrozen, soil_moisture_unfrozen
+      levels = 1, 2, 3, 4
+      vars_labels = '10 cm','40 cm','100 cm','200 cm'
+      y_label = '$m^3$ $m^{-3}$'
+    [[[surface_prcp_inst]]]
+      vars = tprcp_inst, mp_prcp_inst, dcnv_prcp_inst, scnv_prcp_inst
+      vars_labels = 'total','microphysics','deep conv.','shal conv.'
+      y_label = '$m$'
+    [[[surface_prcp_accum]]]
+      vars = tprcp_accum, ice_accum, snow_accum, graupel_accum, conv_prcp_accum
+      vars_labels = 'total','ice','snow','graupel','conv'
+      y_label = '$m$'
+    [[[surface_prcp_rate_accum]]]
+      vars = tprcp_rate_accum, ice_rate_accum, snow_rate_accum, graupel_rate_accum, conv_prcp_rate_accum
+      vars_labels = 'total','ice','snow','graupel','conv'
+      y_label = '$mm$ $h^{-1}$'
+      conversion_factor = 3.6E6
+    [[[surface_sw_down]]]
+      vars = sfc_dwn_sw, sfc_dwn_sw_dir_nir, sfc_dwn_sw_dif_nir, sfc_dwn_sw_dir_vis, sfc_dwn_sw_dif_vis
+      vars_labels = 'sfc downwelling SW (total)', 'sfc downwelling SW (direct near-infrared)','sfc downwelling SW (diffuse near-infrared)','sfc downwelling SW (direct uv+vis)','sfc downwelling SW (diffuse uv+vis)'
+      y_label = '($W$ $m^{-2}$)'
+    [[[surface_sw_up]]]
+      vars = sfc_up_sw, sfc_up_sw_dir_nir, sfc_up_sw_dif_nir, sfc_up_sw_dir_vis, sfc_up_sw_dif_vis
+      vars_labels = 'sfc upwelling SW (total)','sfc upwelling SW (direct near-infrared)','sfc upwelling SW (diffuse near-infrared)', 'sfc upwelling SW (direct uv+vis)','sfc upwelling SW (diffuse uv+vis)'
+      y_label = '($W$ $m^{-2}$)'
+    [[[surface_lw]]]
+      vars = sfc_dwn_lw, sfc_up_lw_land, sfc_up_lw_ocean, sfc_up_lw_ice
+      vars_labels = 'sfc downwelling LW (total)','sfc upwelling LW (land)','sfc upwelling LW (ocean)','sfc upwelling LW (ice)'
+      y_label = '($W$ $m^{-2}$)'
+  
+  [[contours]]
+    vars = qv, T, u, v, qc, ql, qi
+    vars_labels = 'specific humidity ($g$ $kg^{-1}$)', 'T (K)', 'u ($m$ $s^{-1}$)', 'v ($m$ $s^{-1}$)', 'total cloud water (res + sgs) ($g$ $kg^{-1}$)', 'res. liquid cloud water ($g$ $kg^{-1}$)', 'res. ice cloud water ($g$ $kg^{-1}$)'
+    vert_axis = pres_l
+    vert_axis_label = 'p (Pa)'
+    y_inverted = True
+    y_log = False
+    y_min_option = val             #min, max, val (if val, add y_min = float value)
+    y_min = 10000.0
+    y_max_option = val              #min, max, val (if val, add y_max = float value)
+    y_max = 100000.0
+    x_ticks_num = 10
+    y_ticks_num = 10
+    conversion_factor = 1000.0, 1.0, 1.0, 1.0, 1000.0, 1000.0, 1000.0

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -1112,6 +1112,7 @@ module GFS_typedefs
     logical              :: lprnt           !< control flag for diagnostic print out
     logical              :: lsswr           !< logical flags for sw radiation calls
     logical              :: lslwr           !< logical flags for lw radiation calls
+    logical              :: no_rad          !< flag to turn off all radiation calls
     real(kind=kind_phys) :: solhr           !< hour time after 00z at the t-step
     real(kind=kind_phys) :: solcon          !< solar constant (sun-earth distant adjusted)  [set via radupdate]
     real(kind=kind_phys) :: slag            !< equation of time ( radian )                  [set via radupdate]
@@ -4171,6 +4172,7 @@ module GFS_typedefs
     Model%lprnt            = .false.
     Model%lsswr            = .false.
     Model%lslwr            = .false.
+    Model%no_rad           = .false.
     Model%solhr            = -9999.
     Model%solcon           = -9999.
     Model%slag             = -9999.
@@ -5086,6 +5088,7 @@ module GFS_typedefs
       print *, ' lprnt             : ', Model%lprnt
       print *, ' lsswr             : ', Model%lsswr
       print *, ' lslwr             : ', Model%lslwr
+      print *, ' no_rad            : ', Model%no_rad
       print *, ' solhr             : ', Model%solhr
       print *, ' solcon            : ', Model%solcon
       print *, ' slag              : ', Model%slag

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -1112,7 +1112,6 @@ module GFS_typedefs
     logical              :: lprnt           !< control flag for diagnostic print out
     logical              :: lsswr           !< logical flags for sw radiation calls
     logical              :: lslwr           !< logical flags for lw radiation calls
-    logical              :: no_rad          !< flag to turn off all radiation calls
     real(kind=kind_phys) :: solhr           !< hour time after 00z at the t-step
     real(kind=kind_phys) :: solcon          !< solar constant (sun-earth distant adjusted)  [set via radupdate]
     real(kind=kind_phys) :: slag            !< equation of time ( radian )                  [set via radupdate]
@@ -4172,7 +4171,6 @@ module GFS_typedefs
     Model%lprnt            = .false.
     Model%lsswr            = .false.
     Model%lslwr            = .false.
-    Model%no_rad           = .false.
     Model%solhr            = -9999.
     Model%solcon           = -9999.
     Model%slag             = -9999.
@@ -5088,7 +5086,6 @@ module GFS_typedefs
       print *, ' lprnt             : ', Model%lprnt
       print *, ' lsswr             : ', Model%lsswr
       print *, ' lslwr             : ', Model%lslwr
-      print *, ' no_rad            : ', Model%no_rad
       print *, ' solhr             : ', Model%solhr
       print *, ' solcon            : ', Model%solcon
       print *, ' slag              : ', Model%slag

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -4516,6 +4516,12 @@
   units = flag
   dimensions = ()
   type = logical
+[no_rad]
+  standard_name = flag_to_deactivate_radiation
+  long_name = logical flag set to true to turn off radiation completely
+  units = flag
+  dimensions = ()
+  type = logical
 [solhr]
   standard_name = forecast_hour_of_the_day
   long_name = time in hours after 00z at the current timestep

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -4516,12 +4516,6 @@
   units = flag
   dimensions = ()
   type = logical
-[no_rad]
-  standard_name = flag_to_deactivate_radiation
-  long_name = logical flag set to true to turn off radiation completely
-  units = flag
-  dimensions = ()
-  type = logical
 [solhr]
   standard_name = forecast_hour_of_the_day
   long_name = time in hours after 00z at the current timestep

--- a/scm/src/gmtb_scm.F90
+++ b/scm/src/gmtb_scm.F90
@@ -50,7 +50,7 @@ subroutine gmtb_scm_main_sub()
   end select
   
   call get_reference_profile(scm_state, scm_reference)
-  
+
   select case(trim(adjustl(scm_state%model_name)))
     case("GFS")
       !>  - Call get_GFS_grid in \ref vgrid to read in the necessary coefficients and calculate the pressure-related variables on the grid.
@@ -72,7 +72,7 @@ subroutine gmtb_scm_main_sub()
   end select
 
   !allocate(cdata_cols(scm_state%n_cols))
-  
+
   call set_state(scm_input, scm_reference, scm_state)
 
   call calc_geopotential(1, scm_state)
@@ -324,7 +324,6 @@ subroutine gmtb_scm_main_sub()
   !end if
 
   do i = 2, scm_state%n_timesteps
-    
     !are we still in spinup mode?
     if (scm_state%do_spinup .and. i <= scm_state%spinup_timesteps) then
       in_spinup = .true.
@@ -351,18 +350,18 @@ subroutine gmtb_scm_main_sub()
       scm_state%temp_u = scm_state%state_u
       scm_state%temp_v = scm_state%state_v
     end if
-    
+
     call interpolate_forcing(scm_input, scm_state, in_spinup)
     
     call calc_pres_exner_geopotential(1, scm_state)
-    
+
     !zero out diagnostics output on EVERY time step - breaks diagnostics averaged over many timesteps
     !call physics%Diag%rad_zero(physics%Model)
     !call physics%Diag%phys_zero(physics%Model)
 
     !pass in state variables to be modified by forcing and physics
     call do_time_step(scm_state, physics, cdata, in_spinup)
-    
+
     if (scm_state%time_scheme == 2) then
       !for filtered-leapfrog scheme, call the filtering routine to calculate values of the state variables to save in slot 1 using slot 2 vars (updated, unfiltered) output from the physics
       call filter(scm_state)
@@ -389,7 +388,6 @@ subroutine gmtb_scm_main_sub()
       end if
 
     end if
-    
   end do
 
   call ccpp_physics_finalize(cdata, suite_name=trim(trim(adjustl(scm_state%physics_suite_name))), ierr=ierr)

--- a/scm/src/gmtb_scm_forcing.F90
+++ b/scm/src/gmtb_scm_forcing.F90
@@ -35,7 +35,9 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
     v_g_bracket(2,scm_state%n_levels), u_nudge_bracket(2,scm_state%n_levels), v_nudge_bracket(2,scm_state%n_levels), &
     T_nudge_bracket(2,scm_state%n_levels), thil_nudge_bracket(2,scm_state%n_levels), qt_nudge_bracket(2,scm_state%n_levels), &
     dT_dt_rad_bracket(2,scm_state%n_levels), h_advec_thil_bracket(2,scm_state%n_levels),h_advec_qt_bracket(2,scm_state%n_levels), &
-    v_advec_thil_bracket(2,scm_state%n_levels), v_advec_qt_bracket(2,scm_state%n_levels) !< forcing terms that "bracket" around the model time
+    v_advec_thil_bracket(2,scm_state%n_levels), v_advec_qt_bracket(2,scm_state%n_levels),tot_advec_T_bracket(2,scm_state%n_levels),&
+    tot_advec_theta_bracket(2,scm_state%n_levels), tot_advec_thetal_bracket(2,scm_state%n_levels), tot_advec_qv_bracket(2,scm_state%n_levels), &
+    tot_advec_u_bracket(2,scm_state%n_levels), tot_advec_v_bracket(2,scm_state%n_levels) !< forcing terms that "bracket" around the model time
 
   !> \section interpolate_forcing_alg Algorithm
   !! @{
@@ -155,128 +157,394 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
         exit
       end if
     end do
+    
+    if(scm_state%input_type == 0) then
+    
+      do i=1, scm_state%n_cols
+        !>  - For all forcing terms, call interpolate_to_grid_centers from \ref utils for each variable for each time level that "bracket" around
+        !>    the current model time. This subroutine returns the last vertical index calculated in case forcing terms above the case input needs
+        !>    to be specified.
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_w_ls(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, w_ls_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_w_ls(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, w_ls_bracket(2,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_omega(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, omega_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_omega(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, omega_bracket(2,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_g(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, u_g_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_g(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, u_g_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_g(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_g_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_g(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_g_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_nudge(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, u_nudge_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_nudge(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, u_nudge_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_nudge(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_nudge_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_nudge(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_nudge_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_T_nudge(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, T_nudge_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_T_nudge(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, T_nudge_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_thil_nudge(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, thil_nudge_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_thil_nudge(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, thil_nudge_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_qt_nudge(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, qt_nudge_bracket(1,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_qt_nudge(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, qt_nudge_bracket(2,:), top_index, 1)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_dT_dt_rad(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, dT_dt_rad_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_dT_dt_rad(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, dT_dt_rad_bracket(2,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_h_advec_thetail(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, h_advec_thil_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, &
+          scm_input%input_h_advec_thetail(low_t_index+1,:), scm_state%pres_l(i,:), scm_state%n_levels, &
+          h_advec_thil_bracket(2,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_h_advec_qt(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, h_advec_qt_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_h_advec_qt(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, h_advec_qt_bracket(2,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_advec_thetail(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_advec_thil_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, &
+          scm_input%input_v_advec_thetail(low_t_index+1,:), scm_state%pres_l(i,:), scm_state%n_levels, &
+          v_advec_thil_bracket(2,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_advec_qt(low_t_index,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_advec_qt_bracket(1,:), top_index, 3)
+        call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_advec_qt(low_t_index+1,:), &
+          scm_state%pres_l(i,:), scm_state%n_levels, v_advec_qt_bracket(2,:), top_index, 3)
 
-    do i=1, scm_state%n_cols
-      !>  - For all forcing terms, call interpolate_to_grid_centers from \ref utils for each variable for each time level that "bracket" around
-      !>    the current model time. This subroutine returns the last vertical index calculated in case forcing terms above the case input needs
-      !>    to be specified.
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_w_ls(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, w_ls_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_w_ls(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, w_ls_bracket(2,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_omega(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, omega_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_omega(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, omega_bracket(2,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_g(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, u_g_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_g(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, u_g_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_g(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_g_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_g(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_g_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_nudge(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, u_nudge_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_nudge(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, u_nudge_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_nudge(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_nudge_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_nudge(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_nudge_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_T_nudge(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, T_nudge_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_T_nudge(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, T_nudge_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_thil_nudge(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, thil_nudge_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_thil_nudge(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, thil_nudge_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_qt_nudge(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, qt_nudge_bracket(1,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_qt_nudge(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, qt_nudge_bracket(2,:), top_index, 1)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_dT_dt_rad(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, dT_dt_rad_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_dT_dt_rad(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, dT_dt_rad_bracket(2,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_h_advec_thetail(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, h_advec_thil_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, &
-        scm_input%input_h_advec_thetail(low_t_index+1,:), scm_state%pres_l(i,:), scm_state%n_levels, &
-        h_advec_thil_bracket(2,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_h_advec_qt(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, h_advec_qt_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_h_advec_qt(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, h_advec_qt_bracket(2,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_advec_thetail(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_advec_thil_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, &
-        scm_input%input_v_advec_thetail(low_t_index+1,:), scm_state%pres_l(i,:), scm_state%n_levels, &
-        v_advec_thil_bracket(2,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_advec_qt(low_t_index,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_advec_qt_bracket(1,:), top_index, 3)
-      call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_advec_qt(low_t_index+1,:), &
-        scm_state%pres_l(i,:), scm_state%n_levels, v_advec_qt_bracket(2,:), top_index, 3)
+        !>  - If the input forcing file does not reach to the model domain top, fill in values above the input forcing file domain with those from the top level.
+        if (top_index < scm_state%n_levels) then
+          w_ls_bracket(1,top_index+1:scm_state%n_levels) = 0.0!w_ls_bracket(1,top_index)
+          w_ls_bracket(2,top_index+1:scm_state%n_levels) = 0.0!w_ls_bracket(2,top_index)
+          omega_bracket(1,top_index+1:scm_state%n_levels) = 0.0!omega_bracket(1,top_index)
+          omega_bracket(2,top_index+1:scm_state%n_levels) = 0.0!omega_bracket(2,top_index)
+          u_g_bracket(1,top_index+1:scm_state%n_levels) = u_g_bracket(1,top_index)
+          u_g_bracket(2,top_index+1:scm_state%n_levels) = u_g_bracket(2,top_index)
+          v_g_bracket(1,top_index+1:scm_state%n_levels) = v_g_bracket(1,top_index)
+          v_g_bracket(2,top_index+1:scm_state%n_levels) = v_g_bracket(2,top_index)
+          u_nudge_bracket(1,top_index+1:scm_state%n_levels) = u_nudge_bracket(1,top_index)
+          u_nudge_bracket(2,top_index+1:scm_state%n_levels) = u_nudge_bracket(2,top_index)
+          v_nudge_bracket(1,top_index+1:scm_state%n_levels) = v_nudge_bracket(1,top_index)
+          v_nudge_bracket(2,top_index+1:scm_state%n_levels) = v_nudge_bracket(2,top_index)
+          T_nudge_bracket(1,top_index+1:scm_state%n_levels) = T_nudge_bracket(1,top_index)
+          T_nudge_bracket(2,top_index+1:scm_state%n_levels) = T_nudge_bracket(2,top_index)
+          thil_nudge_bracket(1,top_index+1:scm_state%n_levels) = thil_nudge_bracket(1,top_index)
+          thil_nudge_bracket(2,top_index+1:scm_state%n_levels) = thil_nudge_bracket(2,top_index)
+          qt_nudge_bracket(1,top_index+1:scm_state%n_levels) = qt_nudge_bracket(1,top_index)
+          qt_nudge_bracket(2,top_index+1:scm_state%n_levels) = qt_nudge_bracket(2,top_index)
+          dT_dt_rad_bracket(1,top_index+1:scm_state%n_levels) = dT_dt_rad_bracket(1,top_index)
+          dT_dt_rad_bracket(2,top_index+1:scm_state%n_levels) = dT_dt_rad_bracket(2,top_index)
+          h_advec_thil_bracket(1,top_index+1:scm_state%n_levels) = h_advec_thil_bracket(1,top_index)
+          h_advec_thil_bracket(2,top_index+1:scm_state%n_levels) = h_advec_thil_bracket(2,top_index)
+          h_advec_qt_bracket(1,top_index+1:scm_state%n_levels) = h_advec_qt_bracket(1,top_index)
+          h_advec_qt_bracket(2,top_index+1:scm_state%n_levels) = h_advec_qt_bracket(2,top_index)
+          v_advec_thil_bracket(1,top_index+1:scm_state%n_levels) = v_advec_thil_bracket(1,top_index)
+          v_advec_thil_bracket(2,top_index+1:scm_state%n_levels) = v_advec_thil_bracket(2,top_index)
+          v_advec_qt_bracket(1,top_index+1:scm_state%n_levels) = v_advec_qt_bracket(1,top_index)
+          v_advec_qt_bracket(2,top_index+1:scm_state%n_levels) = v_advec_qt_bracket(2,top_index)
+        end if
 
-      !>  - If the input forcing file does not reach to the model domain top, fill in values above the input forcing file domain with those from the top level.
-      if (top_index < scm_state%n_levels) then
-        w_ls_bracket(1,top_index+1:scm_state%n_levels) = 0.0!w_ls_bracket(1,top_index)
-        w_ls_bracket(2,top_index+1:scm_state%n_levels) = 0.0!w_ls_bracket(2,top_index)
-        omega_bracket(1,top_index+1:scm_state%n_levels) = 0.0!omega_bracket(1,top_index)
-        omega_bracket(2,top_index+1:scm_state%n_levels) = 0.0!omega_bracket(2,top_index)
-        u_g_bracket(1,top_index+1:scm_state%n_levels) = u_g_bracket(1,top_index)
-        u_g_bracket(2,top_index+1:scm_state%n_levels) = u_g_bracket(2,top_index)
-        v_g_bracket(1,top_index+1:scm_state%n_levels) = v_g_bracket(1,top_index)
-        v_g_bracket(2,top_index+1:scm_state%n_levels) = v_g_bracket(2,top_index)
-        u_nudge_bracket(1,top_index+1:scm_state%n_levels) = u_nudge_bracket(1,top_index)
-        u_nudge_bracket(2,top_index+1:scm_state%n_levels) = u_nudge_bracket(2,top_index)
-        v_nudge_bracket(1,top_index+1:scm_state%n_levels) = v_nudge_bracket(1,top_index)
-        v_nudge_bracket(2,top_index+1:scm_state%n_levels) = v_nudge_bracket(2,top_index)
-        T_nudge_bracket(1,top_index+1:scm_state%n_levels) = T_nudge_bracket(1,top_index)
-        T_nudge_bracket(2,top_index+1:scm_state%n_levels) = T_nudge_bracket(2,top_index)
-        thil_nudge_bracket(1,top_index+1:scm_state%n_levels) = thil_nudge_bracket(1,top_index)
-        thil_nudge_bracket(2,top_index+1:scm_state%n_levels) = thil_nudge_bracket(2,top_index)
-        qt_nudge_bracket(1,top_index+1:scm_state%n_levels) = qt_nudge_bracket(1,top_index)
-        qt_nudge_bracket(2,top_index+1:scm_state%n_levels) = qt_nudge_bracket(2,top_index)
-        dT_dt_rad_bracket(1,top_index+1:scm_state%n_levels) = dT_dt_rad_bracket(1,top_index)
-        dT_dt_rad_bracket(2,top_index+1:scm_state%n_levels) = dT_dt_rad_bracket(2,top_index)
-        h_advec_thil_bracket(1,top_index+1:scm_state%n_levels) = h_advec_thil_bracket(1,top_index)
-        h_advec_thil_bracket(2,top_index+1:scm_state%n_levels) = h_advec_thil_bracket(2,top_index)
-        h_advec_qt_bracket(1,top_index+1:scm_state%n_levels) = h_advec_qt_bracket(1,top_index)
-        h_advec_qt_bracket(2,top_index+1:scm_state%n_levels) = h_advec_qt_bracket(2,top_index)
-        v_advec_thil_bracket(1,top_index+1:scm_state%n_levels) = v_advec_thil_bracket(1,top_index)
-        v_advec_thil_bracket(2,top_index+1:scm_state%n_levels) = v_advec_thil_bracket(2,top_index)
-        v_advec_qt_bracket(1,top_index+1:scm_state%n_levels) = v_advec_qt_bracket(1,top_index)
-        v_advec_qt_bracket(2,top_index+1:scm_state%n_levels) = v_advec_qt_bracket(2,top_index)
+        !>  - Interpolate the forcing terms in time.
+        scm_state%w_ls(i,:) = (1.0 - lifrac)*w_ls_bracket(1,:) + lifrac*w_ls_bracket(2,:)
+        scm_state%omega(i,:) = (1.0 - lifrac)*omega_bracket(1,:) + lifrac*omega_bracket(2,:)
+        scm_state%u_g(i,:) = (1.0 - lifrac)*u_g_bracket(1,:) + lifrac*u_g_bracket(2,:)
+        scm_state%v_g(i,:) = (1.0 - lifrac)*v_g_bracket(1,:) + lifrac*v_g_bracket(2,:)
+        scm_state%u_nudge(i,:) = (1.0 - lifrac)*u_nudge_bracket(1,:) + lifrac*u_nudge_bracket(2,:)
+        scm_state%v_nudge(i,:) = (1.0 - lifrac)*v_nudge_bracket(1,:) + lifrac*v_nudge_bracket(2,:)
+        scm_state%T_nudge(i,:) = (1.0 - lifrac)*T_nudge_bracket(1,:) + lifrac*T_nudge_bracket(2,:)
+        scm_state%thil_nudge(i,:) = (1.0 - lifrac)*thil_nudge_bracket(1,:) + lifrac*thil_nudge_bracket(2,:)
+        scm_state%qt_nudge(i,:) = (1.0 - lifrac)*qt_nudge_bracket(1,:) + lifrac*qt_nudge_bracket(2,:)
+        scm_state%dT_dt_rad(i,:) = (1.0 - lifrac)*dT_dt_rad_bracket(1,:) + lifrac*dT_dt_rad_bracket(2,:)
+        scm_state%h_advec_thil(i,:) = (1.0 - lifrac)*h_advec_thil_bracket(1,:) + lifrac*h_advec_thil_bracket(2,:)
+        scm_state%h_advec_qt(i,:) = (1.0 - lifrac)*h_advec_qt_bracket(1,:) + lifrac*h_advec_qt_bracket(2,:)
+        scm_state%v_advec_thil(i,:) = (1.0 - lifrac)*v_advec_thil_bracket(1,:) + lifrac*v_advec_thil_bracket(2,:)
+        scm_state%v_advec_qt(i,:) = (1.0 - lifrac)*v_advec_qt_bracket(1,:) + lifrac*v_advec_qt_bracket(2,:)
+
+        !>  - Interpolate the surface parameters in time.
+        scm_state%pres_surf(i) = (1.0 - lifrac)*scm_input%input_pres_surf(low_t_index) + &
+          lifrac*scm_input%input_pres_surf(low_t_index+1)
+        scm_state%T_surf(i) = (1.0 - lifrac)*scm_input%input_T_surf(low_t_index) + lifrac*scm_input%input_T_surf(low_t_index+1)
+        scm_state%sh_flux(i) = (1.0 - lifrac)*scm_input%input_sh_flux_sfc(low_t_index) + &
+          lifrac*scm_input%input_sh_flux_sfc(low_t_index+1)
+        scm_state%lh_flux(i) = (1.0 - lifrac)*scm_input%input_lh_flux_sfc(low_t_index) + &
+          lifrac*scm_input%input_lh_flux_sfc(low_t_index+1)
+      end do
+    else
+      if (scm_state%force_omega) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_omega(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, omega_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_omega(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, omega_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            omega_bracket(1,top_index+1:scm_state%n_levels) = 0.0!omega_bracket(1,top_index)
+            omega_bracket(2,top_index+1:scm_state%n_levels) = 0.0!omega_bracket(2,top_index)
+          end if
+          
+          scm_state%omega(i,:) = (1.0 - lifrac)*omega_bracket(1,:) + lifrac*omega_bracket(2,:)
+        end do
       end if
-
-      !>  - Interpolate the forcing terms in time.
-      scm_state%w_ls(i,:) = (1.0 - lifrac)*w_ls_bracket(1,:) + lifrac*w_ls_bracket(2,:)
-      scm_state%omega(i,:) = (1.0 - lifrac)*omega_bracket(1,:) + lifrac*omega_bracket(2,:)
-      scm_state%u_g(i,:) = (1.0 - lifrac)*u_g_bracket(1,:) + lifrac*u_g_bracket(2,:)
-      scm_state%v_g(i,:) = (1.0 - lifrac)*v_g_bracket(1,:) + lifrac*v_g_bracket(2,:)
-      scm_state%u_nudge(i,:) = (1.0 - lifrac)*u_nudge_bracket(1,:) + lifrac*u_nudge_bracket(2,:)
-      scm_state%v_nudge(i,:) = (1.0 - lifrac)*v_nudge_bracket(1,:) + lifrac*v_nudge_bracket(2,:)
-      scm_state%T_nudge(i,:) = (1.0 - lifrac)*T_nudge_bracket(1,:) + lifrac*T_nudge_bracket(2,:)
-      scm_state%thil_nudge(i,:) = (1.0 - lifrac)*thil_nudge_bracket(1,:) + lifrac*thil_nudge_bracket(2,:)
-      scm_state%qt_nudge(i,:) = (1.0 - lifrac)*qt_nudge_bracket(1,:) + lifrac*qt_nudge_bracket(2,:)
-      scm_state%dT_dt_rad(i,:) = (1.0 - lifrac)*dT_dt_rad_bracket(1,:) + lifrac*dT_dt_rad_bracket(2,:)
-      scm_state%h_advec_thil(i,:) = (1.0 - lifrac)*h_advec_thil_bracket(1,:) + lifrac*h_advec_thil_bracket(2,:)
-      scm_state%h_advec_qt(i,:) = (1.0 - lifrac)*h_advec_qt_bracket(1,:) + lifrac*h_advec_qt_bracket(2,:)
-      scm_state%v_advec_thil(i,:) = (1.0 - lifrac)*v_advec_thil_bracket(1,:) + lifrac*v_advec_thil_bracket(2,:)
-      scm_state%v_advec_qt(i,:) = (1.0 - lifrac)*v_advec_qt_bracket(1,:) + lifrac*v_advec_qt_bracket(2,:)
-
-      !>  - Interpolate the surface parameters in time.
-      scm_state%pres_surf(i) = (1.0 - lifrac)*scm_input%input_pres_surf(low_t_index) + &
-        lifrac*scm_input%input_pres_surf(low_t_index+1)
-      scm_state%T_surf(i) = (1.0 - lifrac)*scm_input%input_T_surf(low_t_index) + lifrac*scm_input%input_T_surf(low_t_index+1)
-      scm_state%sh_flux(i) = (1.0 - lifrac)*scm_input%input_sh_flux_sfc(low_t_index) + &
-        lifrac*scm_input%input_sh_flux_sfc(low_t_index+1)
-      scm_state%lh_flux(i) = (1.0 - lifrac)*scm_input%input_lh_flux_sfc(low_t_index) + &
-        lifrac*scm_input%input_lh_flux_sfc(low_t_index+1)
-    end do
-  end if
+      
+      if (scm_state%force_w) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_w_ls(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, w_ls_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_w_ls(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, w_ls_bracket(2,:), top_index, 3)
+        
+          if (top_index < scm_state%n_levels) then
+            w_ls_bracket(1,top_index+1:scm_state%n_levels) = 0.0!w_ls_bracket(1,top_index)
+            w_ls_bracket(2,top_index+1:scm_state%n_levels) = 0.0!w_ls_bracket(2,top_index)
+          end if
+          
+          scm_state%w_ls(i,:) = (1.0 - lifrac)*w_ls_bracket(1,:) + lifrac*w_ls_bracket(2,:)
+        end do
+      end if
+      
+      if (scm_state%force_geo) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_g(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, u_g_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_g(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, u_g_bracket(2,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_g(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, v_g_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_g(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, v_g_bracket(2,:), top_index, 1)
+            
+          if (top_index < scm_state%n_levels) then
+            u_g_bracket(1,top_index+1:scm_state%n_levels) = u_g_bracket(1,top_index)
+            u_g_bracket(2,top_index+1:scm_state%n_levels) = u_g_bracket(2,top_index)
+            v_g_bracket(1,top_index+1:scm_state%n_levels) = v_g_bracket(1,top_index)
+            v_g_bracket(2,top_index+1:scm_state%n_levels) = v_g_bracket(2,top_index)
+          end if
+          
+          scm_state%u_g(i,:) = (1.0 - lifrac)*u_g_bracket(1,:) + lifrac*u_g_bracket(2,:)
+          scm_state%v_g(i,:) = (1.0 - lifrac)*v_g_bracket(1,:) + lifrac*v_g_bracket(2,:)
+        end do
+      end if
+      
+      if (scm_state%force_adv_T == 1) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_t(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_t_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_t(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_t_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            tot_advec_t_bracket(1,top_index+1:scm_state%n_levels) = tot_advec_t_bracket(1,top_index)
+            tot_advec_t_bracket(2,top_index+1:scm_state%n_levels) = tot_advec_t_bracket(2,top_index)
+          end if
+          
+          scm_state%tot_advec_t(i,:) = (1.0 - lifrac)*tot_advec_t_bracket(1,:) + lifrac*tot_advec_t_bracket(2,:)
+        end do
+      else if (scm_state%force_adv_T == 2) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_theta(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_theta_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_theta(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_theta_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            tot_advec_theta_bracket(1,top_index+1:scm_state%n_levels) = tot_advec_theta_bracket(1,top_index)
+            tot_advec_theta_bracket(2,top_index+1:scm_state%n_levels) = tot_advec_theta_bracket(2,top_index)
+          end if
+          
+          scm_state%tot_advec_theta(i,:) = (1.0 - lifrac)*tot_advec_theta_bracket(1,:) + lifrac*tot_advec_theta_bracket(2,:)
+        end do
+      else if (scm_state%force_adv_T == 3) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_thetal(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_thetal_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_thetal(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_thetal_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            tot_advec_thetal_bracket(1,top_index+1:scm_state%n_levels) = tot_advec_thetal_bracket(1,top_index)
+            tot_advec_thetal_bracket(2,top_index+1:scm_state%n_levels) = tot_advec_thetal_bracket(2,top_index)
+          end if
+          
+          scm_state%tot_advec_thetal(i,:) = (1.0 - lifrac)*tot_advec_thetal_bracket(1,:) + lifrac*tot_advec_thetal_bracket(2,:)
+        end do
+      end if
+      
+      if (scm_state%force_adv_qv) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_qv(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_qv_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_qv(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_qv_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            tot_advec_qv_bracket(1,top_index+1:scm_state%n_levels) = tot_advec_qv_bracket(1,top_index)
+            tot_advec_qv_bracket(2,top_index+1:scm_state%n_levels) = tot_advec_qv_bracket(2,top_index)
+          end if
+          
+          scm_state%tot_advec_qv(i,:) = (1.0 - lifrac)*tot_advec_qv_bracket(1,:) + lifrac*tot_advec_qv_bracket(2,:)
+        end do
+      end if
+      
+      if (scm_state%force_adv_u) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_u(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_u_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_u(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_u_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            tot_advec_u_bracket(1,top_index+1:scm_state%n_levels) = tot_advec_u_bracket(1,top_index)
+            tot_advec_u_bracket(2,top_index+1:scm_state%n_levels) = tot_advec_u_bracket(2,top_index)
+          end if
+          
+          scm_state%tot_advec_u(i,:) = (1.0 - lifrac)*tot_advec_u_bracket(1,:) + lifrac*tot_advec_u_bracket(2,:)
+        end do
+      end if
+      
+      if (scm_state%force_adv_v) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_v(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_v_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_tot_advec_v(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, tot_advec_v_bracket(2,:), top_index, 3)
+          
+          if (top_index < scm_state%n_levels) then
+            tot_advec_v_bracket(1,top_index+1:scm_state%n_levels) = tot_advec_v_bracket(1,top_index)
+            tot_advec_v_bracket(2,top_index+1:scm_state%n_levels) = tot_advec_v_bracket(2,top_index)
+          end if
+          
+          scm_state%tot_advec_v(i,:) = (1.0 - lifrac)*tot_advec_v_bracket(1,:) + lifrac*tot_advec_v_bracket(2,:)
+        end do
+      end if
+        
+      if (scm_state%force_nudging_t == 1) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_T_nudge(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, T_nudge_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_T_nudge(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, T_nudge_bracket(2,:), top_index, 1)
+        end do
+        
+        if (top_index < scm_state%n_levels) then
+          T_nudge_bracket(1,top_index+1:scm_state%n_levels) = T_nudge_bracket(1,top_index)
+          T_nudge_bracket(2,top_index+1:scm_state%n_levels) = T_nudge_bracket(2,top_index)
+        end if
+        
+        scm_state%T_nudge(i,:) = (1.0 - lifrac)*T_nudge_bracket(1,:) + lifrac*T_nudge_bracket(2,:)
+      else if (scm_state%force_nudging_T == 2 .or. scm_state%force_nudging_T == 3) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_thil_nudge(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, thil_nudge_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_thil_nudge(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, thil_nudge_bracket(2,:), top_index, 1)
+        end do
+        
+        if (top_index < scm_state%n_levels) then
+          thil_nudge_bracket(1,top_index+1:scm_state%n_levels) = thil_nudge_bracket(1,top_index)
+          thil_nudge_bracket(2,top_index+1:scm_state%n_levels) = thil_nudge_bracket(2,top_index)
+        end if
+        scm_state%thil_nudge(i,:) = (1.0 - lifrac)*thil_nudge_bracket(1,:) + lifrac*thil_nudge_bracket(2,:)
+      end if
+      
+      if (scm_state%force_nudging_qv) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_qt_nudge(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, qt_nudge_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_qt_nudge(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, qt_nudge_bracket(2,:), top_index, 1)
+        end do
+        
+        if (top_index < scm_state%n_levels) then
+          qt_nudge_bracket(1,top_index+1:scm_state%n_levels) = qt_nudge_bracket(1,top_index)
+          qt_nudge_bracket(2,top_index+1:scm_state%n_levels) = qt_nudge_bracket(2,top_index)
+        end if
+        
+        scm_state%qt_nudge(i,:) = (1.0 - lifrac)*qt_nudge_bracket(1,:) + lifrac*qt_nudge_bracket(2,:)
+      end if
+      
+      if (scm_state%force_nudging_u) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_nudge(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, u_nudge_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_u_nudge(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, u_nudge_bracket(2,:), top_index, 1)
+        end do
+        
+        if (top_index < scm_state%n_levels) then
+          u_nudge_bracket(1,top_index+1:scm_state%n_levels) = u_nudge_bracket(1,top_index)
+          u_nudge_bracket(2,top_index+1:scm_state%n_levels) = u_nudge_bracket(2,top_index)
+        end if
+        
+        scm_state%u_nudge(i,:) = (1.0 - lifrac)*u_nudge_bracket(1,:) + lifrac*u_nudge_bracket(2,:)
+      end if
+      
+      if (scm_state%force_nudging_u) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_nudge(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, v_nudge_bracket(1,:), top_index, 1)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_v_nudge(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, v_nudge_bracket(2,:), top_index, 1)
+        end do
+        
+        if (top_index < scm_state%n_levels) then
+          v_nudge_bracket(1,top_index+1:scm_state%n_levels) = v_nudge_bracket(1,top_index)
+          v_nudge_bracket(2,top_index+1:scm_state%n_levels) = v_nudge_bracket(2,top_index)
+        end if
+        
+        scm_state%v_nudge(i,:) = (1.0 - lifrac)*v_nudge_bracket(1,:) + lifrac*v_nudge_bracket(2,:)
+      end if
+      
+      if (scm_state%force_rad_T == 1 .or. scm_state%force_rad_T == 2 .or. scm_state%force_rad_T == 3) then
+        do i=1, scm_state%n_cols
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_dT_dt_rad(low_t_index,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, dT_dt_rad_bracket(1,:), top_index, 3)
+          call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres, scm_input%input_dT_dt_rad(low_t_index+1,:), &
+            scm_state%pres_l(i,:), scm_state%n_levels, dT_dt_rad_bracket(2,:), top_index, 3)
+        end do
+        
+        if (top_index < scm_state%n_levels) then
+          dT_dt_rad_bracket(1,top_index+1:scm_state%n_levels) = dT_dt_rad_bracket(1,top_index)
+          dT_dt_rad_bracket(2,top_index+1:scm_state%n_levels) = dT_dt_rad_bracket(2,top_index)
+        end if
+        
+        scm_state%dT_dt_rad(i,:) = (1.0 - lifrac)*dT_dt_rad_bracket(1,:) + lifrac*dT_dt_rad_bracket(2,:)
+      end if
+      
+      if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1) then
+        !skin temperature is needed if surface fluxes are specified (for calculating bulk Richardson number in the specified surface flux scheme) and for simple ocean scheme
+        do i=1, scm_state%n_cols
+          scm_state%T_surf(i) = (1.0 - lifrac)*scm_input%input_T_surf(low_t_index) + lifrac*scm_input%input_T_surf(low_t_index+1)
+        end do
+      end if
+      
+      if (scm_state%surface_thermo_control == 0) then
+        do i=1, scm_state%n_cols
+          scm_state%sh_flux(i) = (1.0 - lifrac)*scm_input%input_sh_flux_sfc(low_t_index) + &
+            lifrac*scm_input%input_sh_flux_sfc(low_t_index+1)
+          scm_state%lh_flux(i) = (1.0 - lifrac)*scm_input%input_lh_flux_sfc(low_t_index) + &
+            lifrac*scm_input%input_lh_flux_sfc(low_t_index+1)
+          write(*,*) scm_state%sh_flux(i)
+        end do
+      end if
+      
+      do i=1, scm_state%n_cols
+        !Interpolate the surface parameters in time.
+        scm_state%pres_surf(i) = (1.0 - lifrac)*scm_input%input_pres_surf(low_t_index) + &
+          lifrac*scm_input%input_pres_surf(low_t_index+1)
+      end do
+    end if !input type
+  end if !model time exceeds forcing time
 
   !> @}
 end subroutine interpolate_forcing
@@ -658,6 +926,318 @@ subroutine apply_forcing_forward_Euler(scm_state, in_spinup)
   !> @}
 
 end subroutine apply_forcing_forward_Euler
+
+subroutine apply_forcing_DEPHY(scm_state, in_spinup)
+  use gmtb_scm_type_defs, only: scm_state_type
+
+  type(scm_state_type), intent(inout) :: scm_state
+  logical, intent(in) :: in_spinup
+  
+  real(kind=dp) :: old_u(scm_state%n_cols, scm_state%n_levels), old_v(scm_state%n_cols, scm_state%n_levels), &
+    old_T(scm_state%n_cols, scm_state%n_levels), old_qv(scm_state%n_cols, scm_state%n_levels)
+  real(kind=dp) :: theta(scm_state%n_cols, scm_state%n_levels)
+  
+  real(kind=dp) :: spinup_relax_time, omega_asc, omega_des, w_asc, w_des, gradient_asc, gradient_des, rho, adiabatic_exp_comp_term, &
+                   f_coriolis
+  
+  integer :: i,k
+  
+  logical :: use_theta  !formulations using potential temperature don't need adiabatic expansion/compression term (simpler), 
+                        !but reqires conversion to/from since absolute temperature is state variable
+  
+  use_theta = .false.
+  spinup_relax_time = scm_state%dt
+  
+  !Save old state variables
+  old_u = scm_state%state_u(:,:,1)
+  old_v = scm_state%state_v(:,:,1)
+  old_T = scm_state%state_T(:,:,1)
+  old_qv = scm_state%state_tracer(:,:,scm_state%water_vapor_index,1)
+  
+  if (use_theta) then
+    theta = old_T/scm_state%exner_l(:,:)
+  end if
+
+  !Initialize forcing sums to zero.
+  scm_state%u_force_tend = 0.0
+  scm_state%v_force_tend = 0.0
+  scm_state%T_force_tend = 0.0
+  scm_state%qv_force_tend = 0.0
+  
+  if (in_spinup) then
+    do i=1, scm_state%n_cols
+      do k=1, scm_state%n_levels
+        !accumulate forcing tendencies
+        scm_state%u_force_tend(i,k) = (scm_state%u_nudge(i,k) - old_u(i,k))/spinup_relax_time
+        scm_state%v_force_tend(i,k) = (scm_state%v_nudge(i,k) - old_v(i,k))/spinup_relax_time
+      end do
+    end do
+    do i=1, scm_state%n_cols
+      do k=1, scm_state%n_levels
+        !accumulate forcing tendencies
+        scm_state%T_force_tend(i,k) = (scm_state%T_nudge(i,k) - old_T(i,k))/spinup_relax_time
+        scm_state%qv_force_tend(i,k) = (scm_state%qt_nudge(i,k) - old_qv(i,k))/spinup_relax_time
+      end do
+    end do
+  else
+    if (scm_state%force_omega) then
+      if (scm_state%force_sub_for_T) then
+        if (use_theta) then
+          do i=1, scm_state%n_cols
+            do k=2, scm_state%n_levels-1
+              omega_asc = MIN(scm_state%omega(i,k), 0.0)
+              omega_des = MAX(scm_state%omega(i,k), 0.0)
+              gradient_asc = (theta(i,k) - theta(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+              gradient_des = (theta(i,k+1) - theta(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+              scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + scm_state%exner_l(i,k)*(-omega_asc*gradient_asc - omega_des*gradient_des)
+            end do
+          end do
+        else
+          do i=1, scm_state%n_cols
+            do k=2, scm_state%n_levels-1
+              omega_asc = MIN(scm_state%omega(i,k), 0.0)
+              omega_des = MAX(scm_state%omega(i,k), 0.0)
+              gradient_asc = (old_T(i,k) - old_T(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+              gradient_des = (old_T(i,k+1) - old_T(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+              rho = scm_state%pres_l(i,k)/(con_rd*old_T(i,k))
+              adiabatic_exp_comp_term = (omega_asc + omega_des)/(con_cp*rho)
+              scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + (-omega_asc*gradient_asc - omega_des*gradient_des) + adiabatic_exp_comp_term
+            end do
+          end do
+        end if !use_theta
+      end if !force_sub_for_T
+      
+      if (scm_state%force_sub_for_qv) then
+        do i=1, scm_state%n_cols
+          do k=2, scm_state%n_levels-1
+            omega_asc = MIN(scm_state%omega(i,k), 0.0)
+            omega_des = MAX(scm_state%omega(i,k), 0.0)
+            gradient_asc = (old_qv(i,k) - old_qv(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+            gradient_des = (old_qv(i,k+1) - old_qv(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+            scm_state%qv_force_tend(i,k) = scm_state%qv_force_tend(i,k) + (-omega_asc*gradient_asc - omega_des*gradient_des)
+          end do
+        end do
+      end if
+      
+      if (scm_state%force_sub_for_u) then
+        do i=1, scm_state%n_cols
+          do k=2, scm_state%n_levels-1
+            omega_asc = MIN(scm_state%omega(i,k), 0.0)
+            omega_des = MAX(scm_state%omega(i,k), 0.0)
+            gradient_asc = (old_u(i,k) - old_u(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+            gradient_des = (old_u(i,k+1) - old_u(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+            scm_state%u_force_tend(i,k) = scm_state%u_force_tend(i,k) + (-omega_asc*gradient_asc - omega_des*gradient_des)
+          end do
+        end do
+      end if
+      
+      if (scm_state%force_sub_for_v) then
+        do i=1, scm_state%n_cols
+          do k=2, scm_state%n_levels-1
+            omega_asc = MIN(scm_state%omega(i,k), 0.0)
+            omega_des = MAX(scm_state%omega(i,k), 0.0)
+            gradient_asc = (old_v(i,k) - old_v(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+            gradient_des = (old_v(i,k+1) - old_v(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+            scm_state%v_force_tend(i,k) = scm_state%v_force_tend(i,k) + (-omega_asc*gradient_asc - omega_des*gradient_des)
+          end do
+        end do
+      end if
+      
+    else if (scm_state%force_w) then
+      if (scm_state%force_sub_for_T) then
+        if (use_theta) then
+          do i=1, scm_state%n_cols
+            do k=2, scm_state%n_levels-1
+              w_asc = MAX(scm_state%w_ls(i,k), 0.0)
+              w_des = MIN(scm_state%w_ls(i,k), 0.0)
+              gradient_asc = (theta(i,k) - theta(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+              gradient_des = (theta(i,k+1) - theta(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+              rho = scm_state%pres_l(i,k)/(con_rd*old_T(i,k))
+              scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + scm_state%exner_l(i,k)*rho*con_g*(w_asc*gradient_asc + w_des*gradient_des)
+            end do
+          end do
+        else
+          do i=1, scm_state%n_cols
+            do k=2, scm_state%n_levels-1
+              w_asc = MAX(scm_state%w_ls(i,k), 0.0)
+              w_des = MIN(scm_state%w_ls(i,k), 0.0)
+              gradient_asc = (old_T(i,k) - old_T(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+              gradient_des = (old_T(i,k+1) - old_T(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+              rho = scm_state%pres_l(i,k)/(con_rd*old_T(i,k))
+              adiabatic_exp_comp_term = -(w_asc + w_des)*con_g/con_cp
+              scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + rho*con_g*(w_asc*gradient_asc + w_des*gradient_des) + adiabatic_exp_comp_term
+            end do
+          end do
+        end if !use_theta
+      end if !force_sub_for_T
+      
+      if (scm_state%force_sub_for_qv) then
+        do i=1, scm_state%n_cols
+          do k=2, scm_state%n_levels-1
+            w_asc = MAX(scm_state%w_ls(i,k), 0.0)
+            w_des = MIN(scm_state%w_ls(i,k), 0.0)
+            gradient_asc = (old_qv(i,k) - old_qv(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+            gradient_des = (old_qv(i,k+1) - old_qv(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+            rho = scm_state%pres_l(i,k)/(con_rd*old_T(i,k))
+            scm_state%qv_force_tend(i,k) = scm_state%qv_force_tend(i,k) + rho*con_g*(w_asc*gradient_asc + w_des*gradient_des)
+          end do
+        end do
+      end if
+      
+      if (scm_state%force_sub_for_u) then
+        do i=1, scm_state%n_cols
+          do k=2, scm_state%n_levels-1
+            w_asc = MAX(scm_state%w_ls(i,k), 0.0)
+            w_des = MIN(scm_state%w_ls(i,k), 0.0)
+            gradient_asc = (old_u(i,k) - old_u(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+            gradient_des = (old_u(i,k+1) - old_u(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+            rho = scm_state%pres_l(i,k)/(con_rd*old_T(i,k))
+            scm_state%u_force_tend(i,k) = scm_state%u_force_tend(i,k) + rho*con_g*(w_asc*gradient_asc + w_des*gradient_des)
+          end do
+        end do
+      end if
+      
+      if (scm_state%force_sub_for_v) then
+        do i=1, scm_state%n_cols
+          do k=2, scm_state%n_levels-1
+            w_asc = MAX(scm_state%w_ls(i,k), 0.0)
+            w_des = MIN(scm_state%w_ls(i,k), 0.0)
+            gradient_asc = (old_v(i,k) - old_v(i,k-1))/(scm_state%pres_l(i,k)-scm_state%pres_l(i,k-1))
+            gradient_des = (old_v(i,k+1) - old_v(i,k))/(scm_state%pres_l(i,k+1)-scm_state%pres_l(i,k))
+            rho = scm_state%pres_l(i,k)/(con_rd*old_T(i,k))
+            scm_state%v_force_tend(i,k) = scm_state%v_force_tend(i,k) + rho*con_g*(w_asc*gradient_asc + w_des*gradient_des)
+          end do
+        end do
+      end if
+      
+    end if !force_omega or force_w
+    
+    if (scm_state%force_geo) then
+      !Add forcing due to geostrophic wind
+      
+      !Calculate Coriolis parameter.
+      do i=1, scm_state%n_cols
+        f_coriolis = 2.0*con_omega*sin(scm_state%lat(i))
+        do k=1, scm_state%n_levels
+          !accumulate forcing tendencies
+          scm_state%u_force_tend(i,k) = scm_state%u_force_tend(i,k) +  f_coriolis*(old_v(i,k) - scm_state%v_g(i,k))
+          scm_state%v_force_tend(i,k) = scm_state%v_force_tend(i,k) -  f_coriolis*(old_u(i,k) - scm_state%u_g(i,k))
+        end do
+      end do
+    end if !force_geo
+    
+    if (scm_state%force_adv_T == 1) then
+      !advection term is in terms of absolute temperature
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + scm_state%tot_advec_t(i,k)
+        end do
+      end do
+    else if (scm_state%force_adv_T == 2) then
+      !advection term is in terms of potential temperature
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + scm_state%exner_l(i,k)*scm_state%tot_advec_theta(i,k)
+        end do
+      end do
+    else if (scm_state%force_adv_T == 3) then
+      !advection term is in terms of liquid potential temperature; since there is no information about advection of cloud water, assume it is zero
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + scm_state%exner_l(i,k)*scm_state%tot_advec_thetal(i,k)
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_adv_qv) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%qv_force_tend(i,k) = scm_state%qv_force_tend(i,k) + scm_state%tot_advec_qv(i,k)
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_adv_u) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%u_force_tend(i,k) = scm_state%u_force_tend(i,k) + scm_state%tot_advec_u(i,k)
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_adv_v) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%v_force_tend(i,k) = scm_state%v_force_tend(i,k) + scm_state%tot_advec_v(i,k)
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_nudging_t == 1) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + (scm_state%T_nudge(i,k) - old_T(i,k))/scm_state%force_nudging_T_time
+        end do
+      end do
+    else if (scm_state%force_nudging_t == 2 .or. scm_state%force_nudging_t == 3) then
+      !assume no cloud water in nudging ice-liquid potential temperature (since no nudging profiles of ql or qi)
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + (scm_state%exner_l(i,k)*scm_state%thil_nudge(i,k) - old_T(i,k))/scm_state%force_nudging_T_time
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_nudging_qv) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%qv_force_tend(i,k) = scm_state%qv_force_tend(i,k) + (scm_state%qt_nudge(i,k) - old_qv(i,k))/scm_state%force_nudging_qv_time
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_nudging_u) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%u_force_tend(i,k) = scm_state%u_force_tend(i,k) + (scm_state%u_nudge(i,k) - old_u(i,k))/scm_state%force_nudging_u_time
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_nudging_v) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%v_force_tend(i,k) = scm_state%v_force_tend(i,k) + (scm_state%v_nudge(i,k) - old_v(i,k))/scm_state%force_nudging_v_time
+        end do
+      end do
+    end if
+    
+    if (scm_state%force_rad_T == 1 .or. scm_state%force_rad_T == 2 .or. scm_state%force_rad_T == 3) then
+      do i=1, scm_state%n_cols
+        do k=1, scm_state%n_levels
+          scm_state%T_force_tend(i,k) = scm_state%T_force_tend(i,k) + scm_state%dT_dt_rad(i,k)
+        end do
+      end do
+    end if
+    
+  end if !in_spinup
+  
+  do i=1, scm_state%n_cols
+    do k=1, scm_state%n_levels
+      !> - Update the state variables using the forward Euler scheme:
+      !!   \f[
+      !!   x^{\tau + 1} = x^{\tau} + \Delta t\frac{\partial x}{\partial t}|^\tau_{forcing}
+      !!   \f]
+      !!   \f$x^{\tau}\f$ is the value at the previous time step and \f$\frac{\partial x}{\partial t}|^\tau_{forcing}\f$ is the sum of forcing terms calculated in this time step.
+      scm_state%state_u(i,k,1) = old_u(i,k) + scm_state%dt*scm_state%u_force_tend(i,k)
+      scm_state%state_v(i,k,1) = old_v(i,k) + scm_state%dt*scm_state%v_force_tend(i,k)
+      scm_state%state_T(i,k,1) = scm_state%state_T(i,k,1) + scm_state%dt*(scm_state%T_force_tend(i,k))
+      scm_state%state_tracer(i,k,scm_state%water_vapor_index,1) = scm_state%state_tracer(i,k,scm_state%water_vapor_index,1) + &
+        scm_state%dt*(scm_state%qv_force_tend(i,k))
+    end do
+  end do
+  
+end subroutine apply_forcing_DEPHY
 
 subroutine set_spinup_nudging(scm_state)
   use gmtb_scm_type_defs, only: scm_state_type

--- a/scm/src/gmtb_scm_forcing.F90
+++ b/scm/src/gmtb_scm_forcing.F90
@@ -4,7 +4,7 @@
 module gmtb_scm_forcing
 
 use gmtb_scm_kinds, only: sp, dp, qp
-use gmtb_scm_utils, only: interpolate_to_grid_centers, find_state_vertical_index_from_input
+use gmtb_scm_utils, only: interpolate_to_grid_centers, find_vertical_index_pressure
 
 use gmtb_scm_physical_constants, only: con_pi, con_omega, con_g, con_cp, con_rd, con_hvap
 
@@ -263,7 +263,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             T_nudge_bracket(1,top_index+1:scm_state%n_levels) = T_nudge_bracket(1,top_index)
           end if
           scm_state%T_nudge(i,:) = T_nudge_bracket(1,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(scm_input%input_ntimes,:), scm_state%pres_l(i,:), scm_input%input_k_T_nudge(scm_input%input_ntimes), scm_state%force_nudging_T_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(scm_input%input_ntimes,scm_input%input_k_T_nudge(scm_input%input_ntimes)), scm_state%pres_l(i,:), scm_state%force_nudging_T_k(i))
         else if (scm_state%force_nudging_T == 2 .or. scm_state%force_nudging_T == 3) then
           do i=1, scm_state%n_cols
             call interpolate_to_grid_centers(scm_input%input_nlev, scm_input%input_pres_forcing(scm_input%input_ntimes,:), scm_input%input_thil_nudge(scm_input%input_ntimes,:), &
@@ -273,7 +273,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             thil_nudge_bracket(1,top_index+1:scm_state%n_levels) = thil_nudge_bracket(1,top_index)
           end if
           scm_state%thil_nudge(i,:) = thil_nudge_bracket(1,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(scm_input%input_ntimes,:), scm_state%pres_l(i,:), scm_input%input_k_thil_nudge(scm_input%input_ntimes), scm_state%force_nudging_T_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(scm_input%input_ntimes,scm_input%input_k_thil_nudge(scm_input%input_ntimes)), scm_state%pres_l(i,:), scm_state%force_nudging_T_k(i))
         end if
         
         if (scm_state%force_nudging_qv) then
@@ -285,7 +285,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             qt_nudge_bracket(1,top_index+1:scm_state%n_levels) = qt_nudge_bracket(1,top_index)
           end if
           scm_state%qt_nudge(i,:) = qt_nudge_bracket(1,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(scm_input%input_ntimes,:), scm_state%pres_l(i,:), scm_input%input_k_qt_nudge(scm_input%input_ntimes), scm_state%force_nudging_qv_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(scm_input%input_ntimes,scm_input%input_k_qt_nudge(scm_input%input_ntimes)), scm_state%pres_l(i,:), scm_state%force_nudging_qv_k(i))
         end if
         
         if (scm_state%force_nudging_u) then
@@ -297,7 +297,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             u_nudge_bracket(1,top_index+1:scm_state%n_levels) = u_nudge_bracket(1,top_index)
           end if
           scm_state%u_nudge(i,:) = u_nudge_bracket(1,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(scm_input%input_ntimes,:), scm_state%pres_l(i,:), scm_input%input_k_u_nudge(scm_input%input_ntimes), scm_state%force_nudging_u_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(scm_input%input_ntimes,scm_input%input_k_u_nudge(scm_input%input_ntimes)), scm_state%pres_l(i,:), scm_state%force_nudging_u_k(i))
         end if
         
         if (scm_state%force_nudging_v) then
@@ -309,7 +309,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             v_nudge_bracket(1,top_index+1:scm_state%n_levels) = v_nudge_bracket(1,top_index)
           end if
           scm_state%v_nudge(i,:) = v_nudge_bracket(1,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(scm_input%input_ntimes,:), scm_state%pres_l(i,:), scm_input%input_k_v_nudge(scm_input%input_ntimes), scm_state%force_nudging_v_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(scm_input%input_ntimes,scm_input%input_k_v_nudge(scm_input%input_ntimes)), scm_state%pres_l(i,:), scm_state%force_nudging_v_k(i))
         end if
         
         if (scm_state%force_rad_T == 1 .or. scm_state%force_rad_T == 2 .or. scm_state%force_rad_T == 3) then
@@ -623,7 +623,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             T_nudge_bracket(2,top_index+1:scm_state%n_levels) = T_nudge_bracket(2,top_index)
           end if
           scm_state%T_nudge(i,:) = (1.0 - lifrac)*T_nudge_bracket(1,:) + lifrac*T_nudge_bracket(2,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(low_t_index,:), scm_state%pres_l(i,:), scm_input%input_k_T_nudge(low_t_index), scm_state%force_nudging_T_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(low_t_index,scm_input%input_k_T_nudge(low_t_index)), scm_state%pres_l(i,:), scm_state%force_nudging_T_k(i))
         end do
       else if (scm_state%force_nudging_T == 2 .or. scm_state%force_nudging_T == 3) then
         do i=1, scm_state%n_cols
@@ -636,7 +636,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             thil_nudge_bracket(2,top_index+1:scm_state%n_levels) = thil_nudge_bracket(2,top_index)
           end if
           scm_state%thil_nudge(i,:) = (1.0 - lifrac)*thil_nudge_bracket(1,:) + lifrac*thil_nudge_bracket(2,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(low_t_index,:), scm_state%pres_l(i,:), scm_input%input_k_thil_nudge(low_t_index), scm_state%force_nudging_T_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(low_t_index,scm_input%input_k_thil_nudge(low_t_index)), scm_state%pres_l(i,:), scm_state%force_nudging_T_k(i))
         end do
       end if
       
@@ -651,7 +651,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             qt_nudge_bracket(2,top_index+1:scm_state%n_levels) = qt_nudge_bracket(2,top_index)
           end if
           scm_state%qt_nudge(i,:) = (1.0 - lifrac)*qt_nudge_bracket(1,:) + lifrac*qt_nudge_bracket(2,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(low_t_index,:), scm_state%pres_l(i,:), scm_input%input_k_qt_nudge(low_t_index), scm_state%force_nudging_qv_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(low_t_index,scm_input%input_k_qt_nudge(low_t_index)), scm_state%pres_l(i,:), scm_state%force_nudging_qv_k(i))
         end do
       end if
       
@@ -666,7 +666,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             u_nudge_bracket(2,top_index+1:scm_state%n_levels) = u_nudge_bracket(2,top_index)
           end if
           scm_state%u_nudge(i,:) = (1.0 - lifrac)*u_nudge_bracket(1,:) + lifrac*u_nudge_bracket(2,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(low_t_index,:), scm_state%pres_l(i,:), scm_input%input_k_u_nudge(low_t_index), scm_state%force_nudging_u_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(low_t_index,scm_input%input_k_u_nudge(low_t_index)), scm_state%pres_l(i,:), scm_state%force_nudging_u_k(i))
         end do
       end if
       
@@ -681,7 +681,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
             v_nudge_bracket(2,top_index+1:scm_state%n_levels) = v_nudge_bracket(2,top_index)
           end if
           scm_state%v_nudge(i,:) = (1.0 - lifrac)*v_nudge_bracket(1,:) + lifrac*v_nudge_bracket(2,:)
-          call find_state_vertical_index_from_input(scm_input%input_pres_forcing(low_t_index,:), scm_state%pres_l(i,:), scm_input%input_k_v_nudge(low_t_index), scm_state%force_nudging_v_k(i))
+          call find_vertical_index_pressure(scm_input%input_pres_forcing(low_t_index,scm_input%input_k_v_nudge(low_t_index)), scm_state%pres_l(i,:), scm_state%force_nudging_v_k(i))
         end do
       end if
       

--- a/scm/src/gmtb_scm_input.F90
+++ b/scm/src/gmtb_scm_input.F90
@@ -854,6 +854,8 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
   use gmtb_scm_type_defs, only : scm_state_type, scm_input_type
   use NetCDF_read, only: NetCDF_read_var, NetCDF_read_att, NetCDF_conditionally_read_var, check, missing_value, missing_value_int
   use gmtb_scm_physical_constants, only: con_hvap, con_hfus, con_cp, con_rocp, con_rd
+  use gmtb_scm_utils, only: find_vertical_index_pressure, find_vertical_index_height
+  
   type(scm_state_type), intent(inout) :: scm_state
   type(scm_input_type), target, intent(inout) :: scm_input
   
@@ -2099,40 +2101,6 @@ subroutine get_tracers(tracer_names)
 
     close (fu)
 end subroutine get_tracers
-
-subroutine find_vertical_index_pressure(p_thresh, pres, k_out)
-  real(kind=sp), intent(in) :: p_thresh
-  real(kind=sp), intent(in) :: pres(:)
-  integer, intent(out) :: k_out
-  
-  integer :: k
-  
-  k_out = -999
-  do k=1, size(pres)
-    if (pres(k) <= p_thresh) then
-      k_out = k
-      exit
-    end if
-  end do
-  
-end subroutine find_vertical_index_pressure
-
-subroutine find_vertical_index_height(z_thresh, height, k_out)
-  real(kind=sp), intent(in) :: z_thresh
-  real(kind=sp), intent(in) :: height(:)
-  integer, intent(out) :: k_out
-  
-  integer k
-  
-  k_out = -999
-  do k=1, size(height)
-    if (height(k) >= z_thresh) then
-      k_out = k
-      exit
-    end if
-  end do
-  
-end subroutine find_vertical_index_height
 
 !> @}
 !> @}

--- a/scm/src/gmtb_scm_output.F90
+++ b/scm/src/gmtb_scm_output.F90
@@ -51,8 +51,8 @@ subroutine output_init(scm_state, physics)
   else
     n_diag = n_timesteps/physics%Model%nszero
   end if
-  n_swrad = n_timesteps/physics%Model%nsswr
-  n_lwrad = n_timesteps/physics%Model%nslwr
+  n_swrad = n_timesteps/physics%Model%nsswr + 1
+  n_lwrad = n_timesteps/physics%Model%nslwr + 1
   
   CALL CHECK(NF90_DEF_DIM(NCID=ncid,NAME="time_inst_dim",LEN=n_inst,DIMID=time_inst_id))
   CALL CHECK(NF90_DEF_DIM(NCID=ncid,NAME="time_diag_dim",LEN=n_diag,DIMID=time_diag_id))
@@ -371,7 +371,7 @@ subroutine output_append(scm_state, physics)
     CALL CHECK(NF90_PUT_VAR(NCID=ncid,VARID=var_id,VALUES=scm_state%model_time,START=(/ scm_state%itt_diag /)))
     call output_append_diag_avg(ncid, scm_state, physics)
   end if
-    
+  
   !> - Close the file.
   CALL CHECK(NF90_CLOSE(ncid))
 

--- a/scm/src/gmtb_scm_time_integration.F90
+++ b/scm/src/gmtb_scm_time_integration.F90
@@ -65,11 +65,25 @@ subroutine do_time_step(scm_state, physics, cdata, in_spinup)
   !> - Call apply_forcing_* from \ref forcing. This routine updates the "input" state variables for the physics call (updates filtered values from previous timestep, if leapfrog scheme). It effectively replaces the change of the state variables due to dynamics.
   select case(scm_state%time_scheme)
     case(1)
-      call apply_forcing_forward_Euler(scm_state, in_spinup)
+      if (scm_state%input_type == 0) then
+        call apply_forcing_forward_Euler(scm_state, in_spinup)
+      else
+        call apply_forcing_DEPHY(scm_state, in_spinup)
+      end if
     case(2)
-      call apply_forcing_leapfrog(scm_state)
+      if (scm_state%input_type == 0) then
+        call apply_forcing_leapfrog(scm_state)
+      else
+        write(*,*) 'The application of forcing terms from the DEPHY file format has not been implemented for the leapfrog time scheme.'
+        stop
+      end if
+      
     case default
-      call apply_forcing_forward_Euler(scm_state, in_spinup)
+      if (scm_state%input_type == 0) then
+        call apply_forcing_forward_Euler(scm_state, in_spinup)
+      else
+        call apply_forcing_DEPHY(scm_state, in_spinup)
+      end if
   end select
 
   if (scm_state%time_scheme == 2) then

--- a/scm/src/gmtb_scm_utils.F90
+++ b/scm/src/gmtb_scm_utils.F90
@@ -119,12 +119,33 @@ module NetCDF_read
   implicit none
   
   real(kind=sp) :: missing_value = -9999.0
+  integer       :: missing_value_int = -9999
+  character (3) :: missing_value_char = "mis"
   
   interface NetCDF_read_var
     module procedure NetCDF_read_var_0d_int
-    module procedure NetCDF_read_var_0d
-    module procedure NetCDF_read_var_1d
-    module procedure NetCDF_read_var_2d
+    module procedure NetCDF_read_var_0d_sp
+    module procedure NetCDF_read_var_1d_sp
+    module procedure NetCDF_read_var_2d_sp
+    module procedure NetCDF_read_var_3d_sp
+    module procedure NetCDF_read_var_4d_sp
+    module procedure NetCDF_read_var_0d_dp
+    module procedure NetCDF_read_var_1d_dp
+    module procedure NetCDF_read_var_2d_dp
+    module procedure NetCDF_read_var_3d_dp
+    module procedure NetCDF_read_var_4d_dp
+  end interface
+  
+  interface NetCDF_conditionally_read_var
+    module procedure NetCDF_conditionally_read_var_3d_sp
+    module procedure NetCDF_conditionally_read_var_4d_sp
+  end interface NetCDF_conditionally_read_var
+  
+  interface NetCDF_read_att
+    module procedure NetCDF_read_att_char
+    module procedure NetCDF_read_att_int
+    module procedure NetCDF_read_att_char_or_int
+    module procedure NetCDF_read_att_sp
   end interface
   
   contains
@@ -152,7 +173,122 @@ module NetCDF_read
     
   end subroutine NetCDF_read_var_0d_int
   
-  subroutine NetCDF_read_var_0d(ncid, var_name, req, var_data)
+  subroutine NetCDF_read_var_0d_sp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=sp), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_0d_sp
+  
+  subroutine NetCDF_read_var_1d_sp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=sp), dimension(:), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_1d_sp
+  
+  subroutine NetCDF_read_var_2d_sp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=sp), dimension(:,:), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_2d_sp
+  
+  subroutine NetCDF_read_var_3d_sp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=sp), dimension(:,:,:), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_3d_sp
+  
+  subroutine NetCDF_read_var_4d_sp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=sp), dimension(:,:,:,:), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_4d_sp
+  
+  subroutine NetCDF_read_var_0d_dp(ncid, var_name, req, var_data)
     
     integer, intent(in) :: ncid
     character (*), intent(in) :: var_name
@@ -173,9 +309,9 @@ module NetCDF_read
       end if
     end if
     
-  end subroutine NetCDF_read_var_0d
+  end subroutine NetCDF_read_var_0d_dp
   
-  subroutine NetCDF_read_var_1d(ncid, var_name, req, var_data)
+  subroutine NetCDF_read_var_1d_dp(ncid, var_name, req, var_data)
     
     integer, intent(in) :: ncid
     character (*), intent(in) :: var_name
@@ -196,9 +332,9 @@ module NetCDF_read
       end if
     end if
     
-  end subroutine NetCDF_read_var_1d
+  end subroutine NetCDF_read_var_1d_dp
   
-  subroutine NetCDF_read_var_2d(ncid, var_name, req, var_data)
+  subroutine NetCDF_read_var_2d_dp(ncid, var_name, req, var_data)
     
     integer, intent(in) :: ncid
     character (*), intent(in) :: var_name
@@ -219,7 +355,53 @@ module NetCDF_read
       end if
     end if
     
-  end subroutine NetCDF_read_var_2d
+  end subroutine NetCDF_read_var_2d_dp
+  
+  subroutine NetCDF_read_var_3d_dp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=dp), dimension(:,:,:), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_3d_dp
+  
+  subroutine NetCDF_read_var_4d_dp(ncid, var_name, req, var_data)
+    
+    integer, intent(in) :: ncid
+    character (*), intent(in) :: var_name
+    logical, intent(in) :: req
+    real(kind=dp), dimension(:,:,:,:), intent(out) :: var_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      call check(NF90_INQ_VARID(ncid,var_name,varID))
+      call check(NF90_GET_VAR(ncid,varID,var_data))
+    else
+      ierr = NF90_INQ_VARID(ncid,var_name,varID)
+      if (ierr /= NF90_NOERR) then
+        var_data = missing_value
+      else
+        call check(NF90_GET_VAR(ncid,varID,var_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_var_4d_dp
   
   !Generic subroutine to check for netCDF I/O errors
   subroutine check(status)
@@ -230,6 +412,170 @@ module NetCDF_read
       stop "stopped"
     end if
   end subroutine check
+  
+  subroutine NetCDF_read_att_int(ncid, var_id, att_name, req, att_data)
+  
+    integer, intent(in) :: ncid, var_id
+    character (*), intent(in) :: att_name
+    logical, intent(in) :: req
+    integer, intent(out) :: att_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
+      if (ierr /= NF90_NOERR) then
+        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        stop
+      else
+        call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+      end if
+    else
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
+      if (ierr /= NF90_NOERR) then
+        att_data = missing_value_int
+      else
+        call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_att_int
+  
+  subroutine NetCDF_read_att_sp(ncid, var_id, att_name, req, att_data)
+  
+    integer, intent(in) :: ncid, var_id
+    character (*), intent(in) :: att_name
+    logical, intent(in) :: req
+    real(kind=sp), intent(out) :: att_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
+      if (ierr /= NF90_NOERR) then
+        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        stop
+      else
+        call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+      end if
+    else
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
+      if (ierr /= NF90_NOERR) then
+        att_data = missing_value
+      else
+        call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_att_sp
+  
+  subroutine NetCDF_read_att_char(ncid, var_id, att_name, req, att_data)
+  
+    integer, intent(in) :: ncid, var_id
+    character (*), intent(in) :: att_name
+    logical, intent(in) :: req
+    character (*), intent(out) :: att_data
+    
+    integer :: varID, ierr
+    
+    if (req) then
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
+      if (ierr /= NF90_NOERR) then
+        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        stop
+      else
+        call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+      end if
+    else
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
+      if (ierr /= NF90_NOERR) then
+        att_data = missing_value_char
+      else
+        call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+      end if
+    end if
+    
+  end subroutine NetCDF_read_att_char
+  
+  subroutine NetCDF_read_att_char_or_int(ncid, var_id, att_name, req, att_data, char_att_data)
+  
+    integer, intent(in) :: ncid, var_id
+    character (*), intent(in) :: att_name
+    logical, intent(in) :: req
+    character (*), intent(out) :: char_att_data
+    integer, intent(out) :: att_data
+    
+    integer :: varID, ierr, type
+    
+    if (req) then
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name, xtype = type)
+      if (ierr /= NF90_NOERR) then
+        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        stop
+      else
+        if (type == NF90_CHAR) then
+          call check(NF90_GET_ATT(ncid, var_id, att_name, char_att_data))
+          att_data = missing_value_int
+        else if (type == NF90_INT) then
+          call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+          char_att_data = missing_value_char
+        else
+          att_data = missing_value_int
+          char_att_data = missing_value_char
+        end if
+      end if
+    else
+      ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name, xtype = type)
+      if (ierr /= NF90_NOERR) then
+        char_att_data = missing_value_char
+        att_data = missing_value_int
+      else
+        if (type == NF90_CHAR) then
+          call check(NF90_GET_ATT(ncid, var_id, att_name, char_att_data))
+          att_data = missing_value_int
+        else if (type == NF90_INT) then
+          call check(NF90_GET_ATT(ncid, var_id, att_name, att_data))
+          char_att_data = missing_value_char
+        else
+          att_data = missing_value_int
+          char_att_data = missing_value_char
+        end if
+      end if
+    end if
+    
+  end subroutine NetCDF_read_att_char_or_int
+  
+  subroutine NetCDF_conditionally_read_var_3d_sp(var_ctl, var_att, var_name, filename, ncid, var_data)
+    integer, intent(in) :: var_ctl, ncid
+    character (*), intent(in) :: var_att, var_name, filename
+    real(kind=sp), dimension(:,:,:), intent(out) :: var_data
+    
+    if (var_ctl > 0) then
+      call NetCDF_read_var(ncid, var_name, .False., var_data)
+      if (maxval(var_data) < 0) then
+        write(*,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
+        stop
+      end if
+    else
+      var_data = missing_value
+    end if
+  end subroutine NetCDF_conditionally_read_var_3d_sp
+  
+  subroutine NetCDF_conditionally_read_var_4d_sp(var_ctl, var_att, var_name, filename, ncid, var_data)
+    integer, intent(in) :: var_ctl, ncid
+    character (*), intent(in) :: var_att, var_name, filename
+    real(kind=sp), dimension(:,:,:,:), intent(out) :: var_data
+    
+    if (var_ctl > 0) then
+      call NetCDF_read_var(ncid, var_name, .False., var_data)
+      if (maxval(var_data) < 0) then
+        write(*,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
+        stop
+      end if
+    else
+      var_data = missing_value
+    end if
+  end subroutine NetCDF_conditionally_read_var_4d_sp
   
 end module NetCDF_read  
 

--- a/scm/src/gmtb_scm_utils.F90
+++ b/scm/src/gmtb_scm_utils.F90
@@ -8,6 +8,11 @@ use gmtb_scm_physical_constants, only: con_rd, con_g
 
 implicit none
 
+interface find_vertical_index_pressure
+  module procedure find_vertical_index_pressure_sp
+  module procedure find_vertical_index_pressure_dp
+end interface
+
 contains
 
 !> \ingroup SCM
@@ -78,23 +83,56 @@ subroutine interpolate_to_grid_centers(n_input_levels, input_pres, input_field, 
   !> @}
 end subroutine
 
-subroutine find_state_vertical_index_from_input(input_pres, pres_l, k_in, k_out)
-  real(kind=dp), intent(in) :: input_pres(:)  !< pressure levels for the input profile (Pa)
-  real(kind=dp), intent(in) :: pres_l(:) !< model pressure levels (Pa)
-  integer, intent(in) :: k_in !< input level index
-  integer, intent(out) :: k_out !< corresponding state level index
+subroutine find_vertical_index_pressure_sp(p_thresh, pres, k_out)
+  real(kind=sp), intent(in) :: p_thresh
+  real(kind=sp), intent(in) :: pres(:)
+  integer, intent(out) :: k_out
   
   integer :: k
   
   k_out = -999
-  do k=1, size(pres_l)
-    if (pres_l(k) <= input_pres(k_in)) then
+  do k=1, size(pres)
+    if (pres(k) <= p_thresh) then
       k_out = k
       exit
     end if
   end do
   
-end subroutine find_state_vertical_index_from_input
+end subroutine find_vertical_index_pressure_sp
+
+subroutine find_vertical_index_pressure_dp(p_thresh, pres, k_out)
+  real(kind=dp), intent(in) :: p_thresh
+  real(kind=dp), intent(in) :: pres(:)
+  integer, intent(out) :: k_out
+  
+  integer :: k
+  
+  k_out = -999
+  do k=1, size(pres)
+    if (pres(k) <= p_thresh) then
+      k_out = k
+      exit
+    end if
+  end do
+  
+end subroutine find_vertical_index_pressure_dp
+
+subroutine find_vertical_index_height(z_thresh, height, k_out)
+  real(kind=sp), intent(in) :: z_thresh
+  real(kind=sp), intent(in) :: height(:)
+  integer, intent(out) :: k_out
+  
+  integer k
+  
+  k_out = -999
+  do k=1, size(height)
+    if (height(k) >= z_thresh) then
+      k_out = k
+      exit
+    end if
+  end do
+  
+end subroutine find_vertical_index_height
 
 subroutine w_to_omega(n_col, n_lev, w, p, T, omega)
   integer, intent(in)    :: n_col


### PR DESCRIPTION
This pull request represents the initial implementation of version 1 of the DEPHY-SCM input format (https://docs.google.com/document/d/118xP04jB9HO7Y2LqWk3HZpZ9n3CFujgzimLI7Ug8vO4/edit?pli=1
). This does not remove support for the existing input format. In a future PR, I will provide a script to convert cases in the existing format to the DEPHY format and include existing cases in the DEPHY format. At that time, it will be possible to remove support for the older format.

This PR was tested with all of the cases in the DEPHY GitHub repo (master branch) found here: 
https://github.com/GdR-DEPHY/DEPHY-SCM
In order for others to test the format, please clone the above repository under the scm/data directory. At some point, it may make sense to make this another submodule of the top level CCPP SCM, but it is not as of this PR. When the DEPHY-SCM repo is cloned, one can make use of the following new cases, with case configuration files appearing in scm/etc/case_config:

1. AMMA_REF
2. ARMCU_E3SM, ARMCU_MESONH, ARMCU_REF
3. AYOTTE_00SC (does not work due to inconsistency in case file - see https://github.com/GdR-DEPHY/DEPHY-SCM/issues/1)
4. BOMEX_REF (does not work due to inconsistency in case file - see https://github.com/GdR-DEPHY/DEPHY-SCM/issues/1)
5. DYNAMO_NSA3a (2-month-long case!), DYNAMO_NSA3a_D1
6. GABLS1_REF (does not work due to inconsistency in case file - see https://github.com/GdR-DEPHY/DEPHY-SCM/issues/1)
7. IHOP_REF
8. MPACE_REF
9. RICO_MESONH
10. SANDU_FAST,SLOW,REF
11. SCMS_REF

Except where noted, all cases were run successfully to completion and some attempt was made to look at plots for the "reasonableness" test.

As part of the DEPHY-format case files, there are global NetCDF attributes that control how the forcing is applied. Some of the global attributes in the DEPHY-format case files effectively replaces namelist variables that are part of the existing case setup in scm/etc/case_config. The namelist variables that are superseded include the following:

1. runtime (deduced from end_date - start_date in the DEPHY-format files)
2. thermo_forcing_type (replaced by individual control of forcing terms)
3. mom_forcing_type (replaced by individual control of forcing terms)
4. relax_time (replaced by individual control of forcing terms)
5. sfc_flux_spec (replaced by individual control of forcing terms)
6. sfc_roughness_length (replaced by global attribute)
7. sfc_type (replaced by global attribute)
8. year, month, day, hour, min (replaced by state date global attribute)

Most of the coding changes to support the new format happen in gmtb_scm_input.f90 and gmtb_scm_forcing.f90.

gmtb_scm_input.f90 changes:

- add reference_profile_dir (used to assume the same as the processed_case_dir, but this causes an issue when DEPHY-SCM is a submodule)
- read NetCDF files that follow the DEPHY-SCM v1 format
- there is no attempt to read in LSM ICs from DEPHY-format files, since LSM-related variables are not in the standard; this will need to be an extension of the format
- conditionally reads variables based on global attributes in the file
- added logical checks for input data based on global attributes
- although the format is capable of support >1 column, it is assumed that the first column will be used for now (does not affect existing DEPHY-SCM cases)
- convert mixing ratios to specific humidities as necessary
- added logic to initialize all of qt, qv, ql, and qi, depending on what is provided in the file
- handle the specification of absolute temperature, potential temperature, and liquid-water potential temperature (since all are supported and any/all may appear in DEPHY-format files)
- handle prescribed surface fluxes in both kinematic and W m-2
- handle separate radiation forcing or radiation forcing included in the temperature advection term (new "no_rad" flag needed in ccpp-physics)
- handle nudging to profiles above a given pressure or height

gmtb_scm_forcing.f90 changes:

- changes to interpolate_forcing() subroutine
 -- keep existing code for old format, but add code for DEPHY-format
 -- only interpolate in space/time based on following new control variables:
  --- force_omega or force_w (force_omega has higher precedent)
  --- forge_geo (geostrophic wind forcing)
  --- force_adv_T (total advective term for temperature, potential temperature, or liquid potential temperature)
  --- force_adv_qv (total advection term for moisture)
  --- force_adv_u,v (total advection term for u,v)
  --- force_nudging_T (uses either temperature or liquid potential temperature profiles)
  --- force_nudging_qv
  --- force_nudging_u,v
  --- surface_thermo_control (0=> prescribed surface fluxes in kinematic form 1=> prescribed surface fluxes in W m-2 2=> prescribed SST for simple ocean model, 3=> LSM)
  -- surface_momentum_control (0=> given roughness length, 1=> time-varying friction velocity (implementation TODO)
- new apply_forcing_DEPHY() subroutine
 -- forcing is modular (all forcing terms are additive into a total forcing tendency term)
 -- force_omega is used if possible, otherwise force_w if present
  --- can use "use_theta" switch to convert to potential temperature before calculating vertical advection term (avoids having to calculate a separate adiabatic compression/expansion term)
  --- if not using "use_theta" the adiabatic compression/expansion term is calculated for straight vertical temperature advection
  -- nudging is applied only above the specified level

other changes:

- main gmtb_scm.f90 file
 -- added call to new case_init subroutine
 -- set the new no_rad variable if necessary
 -- call new apply_forcing routine
- gmtb_scm_setup.F90
 -- handle T and liquid potential temperature ICs as well as ql and qi
- gmtb_scm_time_integration.f90 file
 -- call new apply_forcing subroutine
- gmtb_scm_type_defs.f90 file
 -- allocate/initialize new control and forcing variables
- gmtb_scm_utils.f90 file
 -- extend NetCDF_read_var to single/double precision and more ranks
 -- add conditionally_read_var subroutine try to read variables from NetCDF and return missing if not present
- run_gmtb_scm.py run script
 -- checks the DEPHY-format input file for use of prescribed surface fluxes to properly substitute prescribed-surface flux SDF

TODO in followup PRs:
- DEPHY-SCM does not have initial profiles of trace gases for radiation, particularly ozone; need to implement a separate solution
- implement a time-varying friction velocity in addition to specified roughness length