### PR TITLE
Another specified surface flux input bugfix

### DIFF
--- a/scm/src/gmtb_scm_input.F90
+++ b/scm/src/gmtb_scm_input.F90
@@ -695,8 +695,8 @@ subroutine get_case_init(scm_state, scm_input)
   scm_input%input_lon = input_lon
   scm_input%input_pres_surf = input_pres_surf
   scm_input%input_T_surf = input_T_surf
-  scm_input%input_sh_flux_sfc = input_sh_flux_sfc
-  scm_input%input_lh_flux_sfc = input_lh_flux_sfc
+  scm_input%input_sh_flux_sfc_kin = input_sh_flux_sfc
+  scm_input%input_lh_flux_sfc_kin = input_lh_flux_sfc
   scm_input%input_w_ls = input_w_ls
   scm_input%input_omega = input_omega
   scm_input%input_u_g = input_u_g


### PR DESCRIPTION
This PR fixes another bug reported by @egrell where the kinematic surface fluxes from existing specified surface flux cases were being read into a variable that holds surface fluxes in W m-2. This caused the surface fluxes used in the case to be set to their initial values (0) rather than those read from file.

This should hopefully be the last bugfix for existing specified surface flux cases introduced during the development to support the DEPHY format since I ran the same case using code before the DEPHY changes and, as of this PR, the output was identical.