### PR TITLE
Fix runtime_mult and Update remaining data retrieval scripts

### DIFF
--- a/contrib/get_aerosol_climo.sh
+++ b/contrib/get_aerosol_climo.sh
@@ -20,7 +20,7 @@ data_files=("FV3_aeroclim1" "FV3_aeroclim2" "FV3_aeroclim3" "FV3_aeroclim_optics
 cd $BASEDIR/scm/data/physics_input_data/
 for file in "${data_files[@]}"; do
     echo "Retrieving $file.tar.gz"
-    wget https://github.com/NCAR/ccpp-scm/releases/download/v6.0.0/${file}.tar.gz
+    wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0-beta/${file}.tar.gz
     tar -xvf ${file}.tar.gz
     rm -f ${file}.tar.gz
 done

--- a/contrib/get_mg_inccn_data.sh
+++ b/contrib/get_mg_inccn_data.sh
@@ -16,7 +16,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget https://github.com/NCAR/ccpp-scm/releases/download/v6.0.0/MG_INCCN_data.tar.gz
+wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0-beta/MG_INCCN_data.tar.gz
 tar -xvf MG_INCCN_data.tar.gz
 rm -f MG_INCCN_data.tar.gz
 cd $BASEDIR/

--- a/contrib/get_thompson_tables.sh
+++ b/contrib/get_thompson_tables.sh
@@ -15,7 +15,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget https://github.com/NCAR/ccpp-scm/releases/download/v6.0.0/thompson_tables.tar.gz
+wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0-beta/thompson_tables.tar.gz
 tar -xvf thompson_tables.tar.gz
 rm -f thompson_tables.tar.gz
 cd $BASEDIR/

--- a/scm/src/CMakeLists.txt
+++ b/scm/src/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     set(_ccpp_suites_arg "--suites=${suite_string}")
-    message("Calling CCPP code generator (ccpp_prebuild.py) for SUPPORTED suites ${_ccpp_suites_arg} ...")
+    message("Calling CCPP code generator (ccpp_prebuild.py) for suites listed in scm/src/suite_info.py: ${_ccpp_suites_arg}.")
 endif()
 # Run CCPP prebuild.py
 message (STATUS "Running ccpp_prebuild.py for CCPP")

--- a/scm/src/run_scm.py
+++ b/scm/src/run_scm.py
@@ -261,7 +261,7 @@ class Experiment(object):
 
         if runtime_mult:
             self._runtime_mult = runtime_mult
-            message = 'Existing case namelist runtime multiplied by {0}'.format(self._runtime_mult)
+            message = 'Existing case namelist or DEPHY runtime multiplied by {0}'.format(self._runtime_mult)
             logging.debug(message)
         else:
             self._runtime_mult = None
@@ -460,11 +460,9 @@ class Experiment(object):
                 message = 'The --runtime_mult argument must be greater than 0 ({0} was entered)'.format(self._runtime_mult)
                 logging.critical(message)
                 raise Exception(message)
-            try:
-                old_runtime = case_nml['case_config']['runtime']
-                case_nml['case_config']['runtime'] = old_runtime*self._runtime_mult
-            except KeyError:
-                logging.info('The runtime multiplier argument was set, but the runtime is not set in {0} '.format(self._namelist))
+            else:
+                case_nml['case_config']['runtime_mult'] = self._runtime_mult
+                    
         # If the number of levels is specified, set the namelist value
         if self._levels:
             case_nml['case_config']['n_levels'] = self._levels

--- a/scm/src/scm_type_defs.F90
+++ b/scm/src/scm_type_defs.F90
@@ -135,6 +135,7 @@ module scm_type_defs
     real(kind=dp)                           :: dt !< physics time step (s)
     real(kind=dp)                           :: dt_now !< time step currently being used (if it changes due to time-stepping scheme)
     real(kind=dp)                           :: runtime !< total runtime (s)
+    real(kind=dp)                           :: runtime_mult !< runtime multiplier
     real(kind=dp)                           :: output_period !< how often output is written (s)
     real(kind=dp)                           :: relax_time !< time scale for hor. wind nudging (s)
     real(kind=dp)                           :: deg_to_rad_const !< conversion constant from degrees to radians
@@ -561,6 +562,7 @@ module scm_type_defs
     scm_state%dt = real_zero
     scm_state%dt_now = real_zero
     scm_state%runtime = real_zero
+    scm_state%runtime_mult = 1.0
     scm_state%output_period = real_zero
     scm_state%relax_time = real_zero
     scm_state%deg_to_rad_const = real_zero

--- a/scm/src/suite_info.py
+++ b/scm/src/suite_info.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 
+import sys, os
+
+#DEFAULT_SUITE_BEHAVIOR = 'supported'
+DEFAULT_SUITE_BEHAVIOR = 'regression_test'
+
 class suite(object):
   
     DEFAULT_MAX_TIMESTEP = 1800.0
@@ -72,9 +77,34 @@ def main():
     
     #print supported suites separated by commas
     suite_string = ''
-    for s in suite_list:
-        if s._supported:
-            suite_string += s._name + ',' + s._name + '_ps' + ','  
+    
+    if DEFAULT_SUITE_BEHAVIOR == 'regression_test':
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        sys.path.insert(1, dir_path + '/../../test/')
+        
+        rt_suite_list = []
+        
+        import rt_test_cases
+        import rt_test_cases_sp
+        import rt_test_cases_nvidia
+        
+        for item in rt_test_cases.run_list:
+            rt_suite_list.append(item.get("suite"))
+        
+        for item in rt_test_cases_sp.run_list:
+            rt_suite_list.append(item.get("suite"))
+        
+        for item in rt_test_cases_nvidia.run_list:
+            rt_suite_list.append(item.get("suite"))
+        
+        unique_suite_list = list(set(rt_suite_list))
+        
+        for s in unique_suite_list:    
+            suite_string += s + ',' + s + '_ps' + ','
+    else:
+        for s in suite_list:
+            if s._supported:
+                suite_string += s._name + ',' + s._name + '_ps' + ','  
     print(suite_string[:-1])
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Data retrieval scripts other than get_all_static_data.sh are now updated to grab data from v7.0.0-beta release assets
- @mkavulich reported that the `runtime_mult` run script option was no longer functional after conversion to DEPHY format
-- This was an oversight because the SCM was configured to calculate runtime from the begin/end date in the DEPHY files, ignoring whatever was in the case configuration namelist. In addition, runtime_mult is a run script-only function. Previously, it was simply used to modify the existing case configuration runtime, but for DEPHY cases, runtime wasn't even being provided in the case configuration namelists and would have been ignored anyway by the SCM.
-- These changes move the `runtime_mult` namelist option to be read in by the SCM if available.
-- The runtime listed in the case configuration namelist will be used (if given) even when the case uses the DEPHY format.
-- `runtime_mult` is used to modify the runtime in the SCM code, whether runtime comes from the case configuration namelist OR is calculated from the DEPHY file.