### PR TITLE
UFS-dev PR#281

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/grantfirl/ccpp-physics
-	branch = ufs-dev-PR281
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
SOURCE: Grant (@grantfirl)

DESCRIPTION OF CHANGES:
- Updates CCPP physics from ufs/dev (https://github.com/ufs-community/ccpp-physics/pull/281). No changes to the host model are needed.

ISSUE: None

ASSOCIATED PRs:
https://github.com/NCAR/ccpp-physics/pull/1143


This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
https://github.com/ufs-community/ccpp-physics/pull/281

Associated fv3atm PR:
https://github.com/NOAA-EMC/fv3atm/pull/964

Associated NCAR PR:
https://github.com/NCAR/ccpp-physics/pull/1143

---

REGRESSION TEST CHANGES: None
