### PR TITLE
hotfix: fix environment variable access

### DIFF
--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -209,11 +209,11 @@ jobs:
       if: env.files_exist == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: rt-plots-${{matrix.build-type}}-${artifact_origin}
+        name: rt-plots-${{matrix.build-type}}-${{ env.artifact_origin }}
         path: /home/runner/work/ccpp-scm/ccpp-scm/test/scm_rt_out
 
     - name: Upload SCM RTs as GitHub Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: rt-baselines-${{matrix.build-type}}-${artifact_origin}
+        name: rt-baselines-${{matrix.build-type}}-${{ env.artifact_origin }}
         path: /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES:
  - Change variable access from `${{foo}}` to `${foo}`. Getting the error
  
  ```
  Invalid workflow file: .github/workflows/ci_run_scm_rts.yml#L1
(Line: 212, Col: 15): Unrecognized named-value: 'artifact_origin'. Located at
position 1 within expression: artifact_origin, (Line: 218, Col: 15): Unrecognized 
named-value: 'artifact_origin'. Located at position 1 within expression: artifact_origin

  ```

TESTS:
 - PR should pass
