### PR TITLE
Read RTs from Main Branch Artifacts

### DIFF
--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -33,6 +33,7 @@ jobs:
       dir_rt:     /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
       dir_bl:     /home/runner/work/ccpp-scm/ccpp-scm/test/BL-${{matrix.build-type}}
       artifact_origin: ${{ github.event_name == 'pull_request' && 'PR' || ('main' == 'main' && 'main' || 'PR') }}
+      GH_TOKEN:   ${{ github.token }}
 
     # Workflow steps
     steps:
@@ -182,14 +183,22 @@ jobs:
         mkdir /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}
         ./ci_util.py -b ${{matrix.build-type}}
 
-    - name: Create directory for SCM RT baselines
-      run: mkdir ${dir_bl}
+    - name: Save Artifact Id Numbers and Create Directory for SCM RT baselines
+      run: |
+        mkdir -p ${dir_bl}
+        ARTIFACT_ID=$(gh api \
+        repos/NCAR/ccpp-scm/actions/artifacts \
+        --jq '[.artifacts[] | select(.name == "rt-baselines-Debug-main" and (.expired | not))] | sort_by(.created_at) | last | .workflow_run | .id ')
+        echo "artifact_id=${ARTIFACT_ID}"
+        echo "artifact_id=${ARTIFACT_ID}" >> "$GITHUB_ENV"
 
     - name: Download SCM RT baselines
-      run: |
-        cd ${dir_bl}
-        wget https://dtcenter.ucar.edu/ccpp/rt/rt-baselines-${{matrix.build-type}}.zip
-        unzip rt-baselines-${{matrix.build-type}}.zip
+      uses: actions/download-artifact@v5
+      with:
+        name: rt-baselines-${{matrix.build-type}}-main
+        path: ${dir_bl}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ env.artifact_id }}
 
     - name: Compare SCM RT output to baselines
       run: |


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - Read RTs from main branch artifacts instead of the DTC's server
  - This means the artifacts won't need to be manually uploaded
  - Here a link to the [download-artifact](https://github.com/actions/download-artifact?tab=readme-ov-file#inputs) Github action 

TESTS CONDUCTED: The CI actions from the workflow will test if this works or not, a `github-token` may be needed
