### PR TITLE
hotfix: CI will now download matrix.build-type instead of just Debug

### DIFF
--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -188,7 +188,7 @@ jobs:
         mkdir -p ${dir_bl}
         ARTIFACT_ID=$(gh api \
         repos/NCAR/ccpp-scm/actions/artifacts \
-        --jq '[.artifacts[] | select(.name == "rt-baselines-Debug-main" and (.expired | not))] | sort_by(.created_at) | last | .workflow_run | .id ')
+        --jq '[.artifacts[] | select(.name == "rt-baselines-${{matrix.build-type}}-main" and (.expired | not))] | sort_by(.created_at) | last | .workflow_run | .id ')
         echo "artifact_id=${ARTIFACT_ID}"
         echo "artifact_id=${ARTIFACT_ID}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - Github action `run_scm_rts` was failing for the Release build type because it was looking for Debug artifacts. Simple fix using `${{matrix.build-type}}`

TESTS CONDUCTED: Should pass CI
