### PR TITLE
Disable GitHub Actions RTs on Forks

### DIFF
--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   run_scm_rts:
+    # Don't run in forks
+    if: github.repository == 'NCAR/ccpp-scm'
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest


### PR DESCRIPTION
SOURCE: Soren Rasmusen, NCAR

ISSUE:
 - The SCM RTs were turned on for the `main` branch but no check was added to identify is they were being run from the fork or the upstream. The RTs are currently running on the forks, which could lead to charges if the user goes over the usage limit.

DESCRIPTION OF CHANGES:
  - Don't run SCM RTs on forks. It will charge them and fail anyway since they don't have access to the artifacts for comparison

TESTS CONDUCTED: When a user updates their fork the RTs shouldn't run
