### PR TITLE
Only perform actions on main upstream branch, not forks

### DIFF
--- a/.github/workflows/bld_scm_images.yaml
+++ b/.github/workflows/bld_scm_images.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       # Only build containers when pushing to main
-      - "main"
+      - main
 
 jobs:
   docker:

--- a/.github/workflows/run_scm_rts.yml
+++ b/.github/workflows/run_scm_rts.yml
@@ -2,6 +2,9 @@ name: Build/run the CCPP-SCM, compare to existing baselines (GitHub artifact)
 
 on:
   push:
+    branches:
+      # Only build and run when pushing to main
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NFS NCAR

DESCRIPTION OF CHANGES:
  - Only perform Github `run_scm_rts` action on main upstream branch, not forks

ISSUE: 
 - The `run_scm_rts` Github Actions CI tests will fail if run on a fork since they can't download the artifacts, see [here](https://github.com/scrasmussen/ccpp-scm/actions/runs/23512518342/job/68436880070)