### PR TITLE
New Fix: Only perform actions on main upstream branch, not forks

### DIFF
--- a/.github/workflows/run_scm_rts.yml
+++ b/.github/workflows/run_scm_rts.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   run_scm_rts:
     runs-on: ubuntu-24.04
+    if: github.repository == 'NCAR/ccpp-scm'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NFS NCAR

DESCRIPTION OF CHANGES:
  - Only perform Github `run_scm_rts` action on main upstream branch, not forks
  - Previous #679 didn't fix the issue

ISSUE: 
 - The `run_scm_rts` Github Actions CI tests will fail if run on a fork since they can't download the artifacts, now it is fixed on my forked main, see [here](https://github.com/scrasmussen/ccpp-scm/actions/runs/23611480659/job/68768105957)