### PR TITLE
SCM's ccpp-physics repo is moving to scm/dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,9 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	# url = https://github.com/NCAR/ccpp-physics
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = scm/dev
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,7 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	# url = https://github.com/NCAR/ccpp-physics
-	url = https://github.com/scrasmussen/ccpp-physics
+	url = https://github.com/NCAR/ccpp-physics
 	branch = scm/dev
 [submodule "CMakeModules"]
 	path = CMakeModules


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - SCM will use a `scm/dev` branch in the [NCAR/ccpp-physics](https://github.com/NCAR/ccpp-physics/) repo
     - It has been agreed that the NCAR/ccpp-physics is moving to a new code management style to increase the pace of development. This will require a `scm/dev` branch to be created from [NCAR/ccpp-physics](https://github.com/NCAR/ccpp-physics/)'s main. This branch will be as up-to-date as possible with ccpp-physic's `main` and allow SCM to have a functioning build while it digests new PR's from ccpp-physics 
 - This PR points to @scrasmussen [ccpp-physics scm/dev](https://github.com/scrasmussen/ccpp-physics/tree/scm/dev) branch
     - The branch was created with `git revert 85f313462b0d410df2ff823e7f030e11d949a833` to revert agreed-upon breaking changes in NCAR/ccpp-physics#1187
     - This is a know issue that @grantfirl is working on, once SCM can build the NCAR/ccpp-physics#1187 changes, that PR will be added back into the `scm/dev` branch by reverting the revert commit with `git revert c8d1e9c604af9309abd8521332e764cca2a70a4e`
 - [X] `scm/dev` branch needs to be created from [NCAR/ccpp-physics](https://github.com/NCAR/ccpp-physics/)'s main. Wanted to make sure everyone agrees with this process before doing it. Once that branch is created a PR with [scm/dev](https://github.com/scrasmussen/ccpp-physics/tree/scm/dev) branch will be created


ASSOCIATED PRs:
 -  @scrasmussen's [scm/dev](https://github.com/scrasmussen/ccpp-physics/tree/scm/dev) branch will be PR'ed into `scm/dev` once that is created and this bullet will be update to list that PR number


TESTS CONDUCTED: Built all suites with GNU on Derecho and ran `twpice` case